### PR TITLE
feat: Phase 1 - 로그인 인증, 기기 설정 CRUD, 데이터 보존 정책

### DIFF
--- a/src/main/java/com/smartfarm/server/config/AdminUserInitializer.java
+++ b/src/main/java/com/smartfarm/server/config/AdminUserInitializer.java
@@ -1,0 +1,32 @@
+package com.smartfarm.server.config;
+
+import com.smartfarm.server.entity.User;
+import com.smartfarm.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminUserInitializer implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (userRepository.findByUsername("admin").isEmpty()) {
+            User admin = User.builder()
+                    .username("admin")
+                    .password(passwordEncoder.encode("admin1234"))
+                    .role("ROLE_ADMIN")
+                    .build();
+            userRepository.save(admin);
+            log.info(">>> 초기 관리자 계정 생성 완료 (admin / admin1234)");
+        }
+    }
+}

--- a/src/main/java/com/smartfarm/server/config/SecurityConfig.java
+++ b/src/main/java/com/smartfarm/server/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -11,21 +13,35 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers(
-                    "/dashboard",
-                    "/dashboard/**",
-                    "/api/**",
-                    "/swagger-ui/**",
-                    "/v3/api-docs/**"
-                ).permitAll()
+                .requestMatchers("/", "/login", "/api/sensor/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()
             )
-            .formLogin(form -> form.disable())
-            .httpBasic(basic -> basic.disable())
-            .csrf(csrf -> csrf.disable());
+            .formLogin(form -> form
+                .loginPage("/")
+                .loginProcessingUrl("/login")
+                .defaultSuccessUrl("/dashboard", true)
+                .failureUrl("/?error=true")
+                .usernameParameter("username")
+                .passwordParameter("password")
+                .permitAll()
+            )
+            .logout(logout -> logout
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/")
+                .permitAll()
+            )
+            .csrf(csrf -> csrf
+                .ignoringRequestMatchers("/api/**")
+            );
 
         return http.build();
     }

--- a/src/main/java/com/smartfarm/server/controller/DeviceConfigController.java
+++ b/src/main/java/com/smartfarm/server/controller/DeviceConfigController.java
@@ -1,0 +1,47 @@
+package com.smartfarm.server.controller;
+
+import com.smartfarm.server.dto.DeviceConfigRequestDto;
+import com.smartfarm.server.dto.DeviceConfigResponseDto;
+import com.smartfarm.server.service.DeviceConfigService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/device-config")
+@RequiredArgsConstructor
+@Tag(name = "3. 기기 설정 API", description = "기기별 온도/습도 임계값 관리")
+public class DeviceConfigController {
+
+    private final DeviceConfigService deviceConfigService;
+
+    @Operation(summary = "전체 기기 설정 조회")
+    @GetMapping
+    public ResponseEntity<List<DeviceConfigResponseDto>> getAllConfigs() {
+        return ResponseEntity.ok(deviceConfigService.getAllDeviceConfigs());
+    }
+
+    @Operation(summary = "특정 기기 설정 조회")
+    @GetMapping("/{deviceId}")
+    public ResponseEntity<DeviceConfigResponseDto> getConfig(@PathVariable String deviceId) {
+        return ResponseEntity.ok(DeviceConfigResponseDto.from(deviceConfigService.getDeviceConfig(deviceId)));
+    }
+
+    @Operation(summary = "기기 설정 저장/수정")
+    @PostMapping
+    public ResponseEntity<DeviceConfigResponseDto> saveOrUpdate(@Valid @RequestBody DeviceConfigRequestDto request) {
+        return ResponseEntity.ok(DeviceConfigResponseDto.from(deviceConfigService.saveOrUpdateDeviceConfig(request)));
+    }
+
+    @Operation(summary = "기기 설정 삭제")
+    @DeleteMapping("/{deviceId}")
+    public ResponseEntity<Void> deleteConfig(@PathVariable String deviceId) {
+        deviceConfigService.deleteDeviceConfig(deviceId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/smartfarm/server/dto/DeviceConfigRequestDto.java
+++ b/src/main/java/com/smartfarm/server/dto/DeviceConfigRequestDto.java
@@ -1,0 +1,20 @@
+package com.smartfarm.server.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeviceConfigRequestDto {
+
+    @NotBlank(message = "디바이스 ID는 필수입니다.")
+    private String deviceId;
+
+    @Positive(message = "온도 임계값은 양수여야 합니다.")
+    private double temperatureThresholdHigh;
+
+    @Positive(message = "습도 임계값은 양수여야 합니다.")
+    private double humidityThresholdHigh;
+}

--- a/src/main/java/com/smartfarm/server/dto/DeviceConfigResponseDto.java
+++ b/src/main/java/com/smartfarm/server/dto/DeviceConfigResponseDto.java
@@ -1,0 +1,24 @@
+package com.smartfarm.server.dto;
+
+import com.smartfarm.server.entity.DeviceConfig;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeviceConfigResponseDto {
+
+    private Long id;
+    private String deviceId;
+    private double temperatureThresholdHigh;
+    private double humidityThresholdHigh;
+
+    public static DeviceConfigResponseDto from(DeviceConfig entity) {
+        return DeviceConfigResponseDto.builder()
+                .id(entity.getId())
+                .deviceId(entity.getDeviceId())
+                .temperatureThresholdHigh(entity.getTemperatureThresholdHigh())
+                .humidityThresholdHigh(entity.getHumidityThresholdHigh())
+                .build();
+    }
+}

--- a/src/main/java/com/smartfarm/server/entity/DeviceConfig.java
+++ b/src/main/java/com/smartfarm/server/entity/DeviceConfig.java
@@ -35,4 +35,9 @@ public class DeviceConfig implements Serializable {
         this.temperatureThresholdHigh = temperatureThresholdHigh;
         this.humidityThresholdHigh = humidityThresholdHigh;
     }
+
+    public void update(double temperatureThresholdHigh, double humidityThresholdHigh) {
+        this.temperatureThresholdHigh = temperatureThresholdHigh;
+        this.humidityThresholdHigh = humidityThresholdHigh;
+    }
 }

--- a/src/main/java/com/smartfarm/server/entity/User.java
+++ b/src/main/java/com/smartfarm/server/entity/User.java
@@ -1,0 +1,33 @@
+package com.smartfarm.server.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String role; // ROLE_ADMIN, ROLE_USER
+
+    @Builder
+    public User(String username, String password, String role) {
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/smartfarm/server/repository/SensorHistoryRepository.java
+++ b/src/main/java/com/smartfarm/server/repository/SensorHistoryRepository.java
@@ -27,4 +27,7 @@ public interface SensorHistoryRepository extends JpaRepository<SensorHistory, Lo
     // 실제 데이터를 전송한 기기 ID 목록을 중복 없이 조회 (대시보드 셀렉터용)
     @Query("SELECT DISTINCT s.deviceId FROM SensorHistory s ORDER BY s.deviceId ASC")
     List<String> findDistinctDeviceIds();
+
+    // 1개월 이상 지난 데이터 삭제 (데이터 보존 정책)
+    void deleteByTimestampBefore(LocalDateTime cutoff);
 }

--- a/src/main/java/com/smartfarm/server/repository/UserRepository.java
+++ b/src/main/java/com/smartfarm/server/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.smartfarm.server.repository;
+
+import com.smartfarm.server.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/smartfarm/server/service/DataBatchService.java
+++ b/src/main/java/com/smartfarm/server/service/DataBatchService.java
@@ -95,4 +95,17 @@ public class DataBatchService {
             log.error("[BATCH TASK] 데이터 집계/이관 중 오류 발생: {}", e.getMessage(), e);
         }
     }
+
+    /**
+     * 매일 새벽 2시에 1개월 이상 지난 SensorHistory 데이터를 삭제합니다.
+     * 데이터 보존 정책: 30일 초과 데이터 자동 정리
+     */
+    @Transactional
+    @Scheduled(cron = "0 0 2 * * *")
+    public void deleteOldSensorHistory() {
+        LocalDateTime cutoff = LocalDateTime.now().minusMonths(1);
+        log.info("[BATCH TASK] 데이터 보존 정책 실행 - {}  이전 데이터 삭제 시작", cutoff);
+        mysqlRepository.deleteByTimestampBefore(cutoff);
+        log.info("[BATCH TASK] 1개월 이상 지난 SensorHistory 데이터 삭제 완료");
+    }
 }

--- a/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
+++ b/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
@@ -1,6 +1,10 @@
 package com.smartfarm.server.service;
 
+import com.smartfarm.server.dto.DeviceConfigRequestDto;
+import com.smartfarm.server.dto.DeviceConfigResponseDto;
 import com.smartfarm.server.entity.DeviceConfig;
+import com.smartfarm.server.exception.CustomException;
+import com.smartfarm.server.exception.ErrorCode;
 import com.smartfarm.server.repository.DeviceConfigRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,13 +14,15 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeviceConfigService {
 
     private final DeviceConfigRepository deviceConfigRepository;
-    
+
     @Value("${smartfarm.sensor.default-temp-threshold}")
     private double defaultTempThreshold;
 
@@ -26,7 +32,7 @@ public class DeviceConfigService {
     @Cacheable(value = "deviceConfigObj", key = "#deviceId")
     public DeviceConfig getDeviceConfig(String deviceId) {
         log.info(">>> DB에서 {} 기기 설정값을 조회합니다. (이 로그가 보이면 캐시 미스 발생!)", deviceId);
-        
+
         return deviceConfigRepository.findByDeviceId(deviceId)
                 .orElseGet(() -> {
                     log.info(">>> 등록된 기기 설정이 없어 기본 설정값을 반환합니다. (온도: {}, 습도: {})", defaultTempThreshold, defaultHumidityThreshold);
@@ -38,10 +44,46 @@ public class DeviceConfigService {
                 });
     }
 
+    public List<DeviceConfigResponseDto> getAllDeviceConfigs() {
+        return deviceConfigRepository.findAll().stream()
+                .map(DeviceConfigResponseDto::from)
+                .toList();
+    }
+
+    /** REST API(DeviceConfigController)에서 호출하는 저장/수정 메서드 */
+    @Transactional
+    @CacheEvict(value = "deviceConfigObj", key = "#request.deviceId")
+    public DeviceConfig saveOrUpdateDeviceConfig(DeviceConfigRequestDto request) {
+        log.info(">>> 기기 설정 저장/수정 및 캐시 삭제: {}", request.getDeviceId());
+
+        DeviceConfig config = deviceConfigRepository.findByDeviceId(request.getDeviceId())
+                .orElse(DeviceConfig.builder()
+                        .deviceId(request.getDeviceId())
+                        .temperatureThresholdHigh(request.getTemperatureThresholdHigh())
+                        .humidityThresholdHigh(request.getHumidityThresholdHigh())
+                        .build());
+
+        if (config.getId() != null) {
+            config.update(request.getTemperatureThresholdHigh(), request.getHumidityThresholdHigh());
+        }
+
+        return deviceConfigRepository.save(config);
+    }
+
+    /** 내부(SensorService)에서 호출하는 기존 저장 메서드 - 하위 호환 유지 */
     @Transactional
     @CacheEvict(value = "deviceConfigObj", key = "#deviceConfig.deviceId")
     public void saveOrUpdateDeviceConfig(DeviceConfig deviceConfig) {
         log.info(">>> 기기 설정 저장 및 캐시 삭제: {}", deviceConfig.getDeviceId());
         deviceConfigRepository.save(deviceConfig);
+    }
+
+    @Transactional
+    @CacheEvict(value = "deviceConfigObj", key = "#deviceId")
+    public void deleteDeviceConfig(String deviceId) {
+        DeviceConfig config = deviceConfigRepository.findByDeviceId(deviceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DEVICE_NOT_FOUND));
+        log.info(">>> 기기 설정 삭제 및 캐시 삭제: {}", deviceId);
+        deviceConfigRepository.delete(config);
     }
 }

--- a/src/main/java/com/smartfarm/server/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/smartfarm/server/service/UserDetailsServiceImpl.java
@@ -1,0 +1,31 @@
+package com.smartfarm.server.service;
+
+import com.smartfarm.server.entity.User;
+import com.smartfarm.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .authorities(List.of(new SimpleGrantedAuthority(user.getRole())))
+                .build();
+    }
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -54,6 +54,121 @@
             color: #94a3b8;
         }
 
+        .header-btn {
+            background: #334155;
+            border: 1px solid #475569;
+            color: #94a3b8;
+            padding: 6px 14px;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            cursor: pointer;
+            text-decoration: none;
+            transition: all 0.2s;
+        }
+
+        .header-btn:hover {
+            background: #475569;
+            color: #e2e8f0;
+        }
+
+        .header-btn.btn-config {
+            border-color: #38bdf8;
+            color: #38bdf8;
+        }
+
+        .header-btn.btn-config:hover {
+            background: #1e3a5f;
+        }
+
+        /* 모달 */
+        .modal-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.6);
+            z-index: 100;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .modal-overlay.active {
+            display: flex;
+        }
+
+        .modal-box {
+            background: #1e293b;
+            border: 1px solid #334155;
+            border-radius: 12px;
+            padding: 28px;
+            width: 100%;
+            max-width: 420px;
+        }
+
+        .modal-box h3 {
+            font-size: 1rem;
+            color: #38bdf8;
+            margin-bottom: 20px;
+        }
+
+        .modal-field {
+            margin-bottom: 16px;
+        }
+
+        .modal-field label {
+            display: block;
+            font-size: 0.8rem;
+            color: #64748b;
+            margin-bottom: 6px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .modal-field input {
+            width: 100%;
+            background: #0f172a;
+            border: 1px solid #334155;
+            color: #e2e8f0;
+            padding: 8px 12px;
+            border-radius: 6px;
+            font-size: 0.9rem;
+        }
+
+        .modal-field input:focus {
+            outline: none;
+            border-color: #38bdf8;
+        }
+
+        .modal-actions {
+            display: flex;
+            gap: 8px;
+            justify-content: flex-end;
+            margin-top: 20px;
+        }
+
+        .btn-save {
+            background: #0369a1;
+            border: none;
+            color: #e2e8f0;
+            padding: 8px 20px;
+            border-radius: 6px;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .btn-save:hover { background: #0284c7; }
+
+        .btn-cancel {
+            background: transparent;
+            border: 1px solid #475569;
+            color: #94a3b8;
+            padding: 8px 20px;
+            border-radius: 6px;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .btn-cancel:hover { background: #334155; }
+
         .status-dot {
             width: 8px;
             height: 8px;
@@ -262,8 +377,36 @@
             <div class="status-dot"></div>
             <span id="lastUpdated">연결 중...</span>
         </div>
+        <button class="header-btn btn-config" onclick="openConfigModal()">&#9881; 기기 설정</button>
+        <form th:action="@{/logout}" method="POST" style="margin:0;">
+            <button type="submit" class="header-btn">로그아웃</button>
+        </form>
     </div>
 </header>
+
+<!-- 기기 설정 모달 -->
+<div class="modal-overlay" id="configModal">
+    <div class="modal-box">
+        <h3>&#9881; 기기 임계값 설정</h3>
+        <div class="modal-field">
+            <label>기기 ID</label>
+            <input type="text" id="configDeviceId" readonly style="color:#64748b; cursor:not-allowed;">
+        </div>
+        <div class="modal-field">
+            <label>고온 임계값 (°C)</label>
+            <input type="number" id="configTempThreshold" step="0.1" min="0" max="150">
+        </div>
+        <div class="modal-field">
+            <label>고습 임계값 (%)</label>
+            <input type="number" id="configHumidityThreshold" step="0.1" min="0" max="100">
+        </div>
+        <div id="configMessage" style="font-size:0.8rem; color:#22c55e; min-height:18px;"></div>
+        <div class="modal-actions">
+            <button class="btn-cancel" onclick="closeConfigModal()">취소</button>
+            <button class="btn-save" onclick="saveConfig()">저장</button>
+        </div>
+    </div>
+</div>
 
 <main>
 
@@ -538,6 +681,61 @@
             select.innerHTML = '<option value="">로드 실패</option>';
         }
     }
+
+    // ─── 기기 설정 모달 ──────────────────────────────────────────
+    async function openConfigModal() {
+        if (!currentDeviceId) return;
+        document.getElementById('configDeviceId').value = currentDeviceId;
+        document.getElementById('configMessage').textContent = '';
+        try {
+            const res = await fetch(`/api/device-config/${encodeURIComponent(currentDeviceId)}`);
+            if (res.ok) {
+                const data = await res.json();
+                document.getElementById('configTempThreshold').value = data.temperatureThresholdHigh;
+                document.getElementById('configHumidityThreshold').value = data.humidityThresholdHigh;
+            }
+        } catch (e) { /* 기본값 유지 */ }
+        document.getElementById('configModal').classList.add('active');
+    }
+
+    function closeConfigModal() {
+        document.getElementById('configModal').classList.remove('active');
+    }
+
+    async function saveConfig() {
+        const deviceId = document.getElementById('configDeviceId').value;
+        const tempThreshold = parseFloat(document.getElementById('configTempThreshold').value);
+        const humidityThreshold = parseFloat(document.getElementById('configHumidityThreshold').value);
+        const msgEl = document.getElementById('configMessage');
+
+        try {
+            const res = await fetch('/api/device-config', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    deviceId,
+                    temperatureThresholdHigh: tempThreshold,
+                    humidityThresholdHigh: humidityThreshold
+                })
+            });
+            if (res.ok) {
+                msgEl.style.color = '#22c55e';
+                msgEl.textContent = '저장되었습니다.';
+                setTimeout(closeConfigModal, 800);
+            } else {
+                msgEl.style.color = '#f87171';
+                msgEl.textContent = '저장에 실패했습니다.';
+            }
+        } catch (e) {
+            msgEl.style.color = '#f87171';
+            msgEl.textContent = '오류가 발생했습니다.';
+        }
+    }
+
+    // 모달 외부 클릭 시 닫기
+    document.getElementById('configModal').addEventListener('click', function(e) {
+        if (e.target === this) closeConfigModal();
+    });
 
     // ─── 초기화 ──────────────────────────────────────────────────
     document.addEventListener('DOMContentLoaded', async () => {

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -4,11 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Smart-PC Farm 로그인</title>
-    <!-- Bootstrap CSS for quick styling -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body {
-            background-color: #f4f6f9;
+            background-color: #0f172a;
             height: 100vh;
             display: flex;
             align-items: center;
@@ -19,13 +18,34 @@
             max-width: 400px;
             padding: 2rem;
             border-radius: 10px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-            background-color: white;
+            box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+            background-color: #1e293b;
+            border: 1px solid #334155;
         }
         .brand-logo {
             text-align: center;
             margin-bottom: 2rem;
-            color: #2c3e50;
+            color: #38bdf8;
+        }
+        .brand-logo p {
+            color: #64748b;
+        }
+        .form-label {
+            color: #94a3b8;
+        }
+        .form-control {
+            background-color: #0f172a;
+            border: 1px solid #334155;
+            color: #e2e8f0;
+        }
+        .form-control:focus {
+            background-color: #0f172a;
+            border-color: #38bdf8;
+            color: #e2e8f0;
+            box-shadow: 0 0 0 0.2rem rgba(56,189,248,0.15);
+        }
+        .form-control::placeholder {
+            color: #475569;
         }
     </style>
 </head>
@@ -33,25 +53,28 @@
 
 <div class="login-card">
     <div class="brand-logo">
-        <h2>🌱 Smart-PC Farm</h2>
-        <p class="text-muted">관리자 대시보드 로그인</p>
+        <h2>&#9651; Smart-PC Farm</h2>
+        <p>관리자 대시보드 로그인</p>
     </div>
 
-    <form action="/dashboard" method="GET">
+    <div th:if="${param.error}" class="alert alert-danger py-2" role="alert">
+        아이디 또는 비밀번호가 올바르지 않습니다.
+    </div>
+    <div th:if="${param.logout}" class="alert alert-success py-2" role="alert">
+        로그아웃 되었습니다.
+    </div>
+
+    <form th:action="@{/login}" method="POST">
         <div class="mb-3">
-            <label for="username" class="form-label">아이디 (추후 연동)</label>
-            <input type="text" class="form-control" id="username" placeholder="admin" required>
+            <label for="username" class="form-label">아이디</label>
+            <input type="text" class="form-control" id="username" name="username" placeholder="admin" required autofocus>
         </div>
         <div class="mb-4">
-            <label for="password" class="form-label">비밀번호 (추후 연동)</label>
-            <input type="password" class="form-control" id="password" placeholder="****" required>
+            <label for="password" class="form-label">비밀번호</label>
+            <input type="password" class="form-control" id="password" name="password" placeholder="****" required>
         </div>
-        <button type="submit" class="btn btn-success w-100">로그인</button>
+        <button type="submit" class="btn btn-primary w-100">로그인</button>
     </form>
-
-    <div class="text-center mt-3">
-        <small class="text-muted">* 현재는 UI 시연용이며, 인증 없이 대시보드로 넘어갑니다.</small>
-    </div>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary

- **로그인/인증**: Spring Security 폼 로그인 활성화, User 엔티티 추가, BCrypt 패스워드 인코딩, 앱 시작 시 admin 계정 자동 생성 (admin / admin1234)
- **DeviceConfig CRUD**: 기기별 온도/습도 임계값 조회·저장·삭제 REST API 추가, 대시보드에 설정 모달 UI 추가
- **데이터 보존 정책**: 매일 새벽 2시 1개월 초과 SensorHistory 자동 삭제 스케줄러 추가

## Changed Files

- `SecurityConfig` — 폼 로그인 활성화, `/api/**` CSRF 예외, `/dashboard` 인증 필수
- `User` / `UserRepository` / `UserDetailsServiceImpl` / `AdminUserInitializer` — 신규 추가
- `DeviceConfigController` / `DeviceConfigRequestDto` / `DeviceConfigResponseDto` — 신규 추가
- `DeviceConfigService` — DTO 기반 CRUD 메서드 추가
- `DeviceConfig` — `update()` 메서드 추가
- `SensorHistoryRepository` — `deleteByTimestampBefore()` 추가
- `DataBatchService` — 데이터 보존 정책 스케줄러 추가
- `login.html` — 실제 Spring Security 폼으로 교체
- `dashboard.html` — 로그아웃 버튼, 기기 설정 모달 추가