### PR TITLE
feat: Phase 2 - SSE 실시간 대시보드 구현

### DIFF
--- a/src/main/java/com/smartfarm/server/controller/SseController.java
+++ b/src/main/java/com/smartfarm/server/controller/SseController.java
@@ -1,0 +1,27 @@
+package com.smartfarm.server.controller;
+
+import com.smartfarm.server.service.SseEmitterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/sse")
+@RequiredArgsConstructor
+@Tag(name = "4. 실시간 SSE API", description = "Server-Sent Events 기반 실시간 센서 데이터 스트림")
+public class SseController {
+
+    private final SseEmitterService sseEmitterService;
+
+    @Operation(summary = "기기 실시간 데이터 구독")
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@RequestParam String deviceId) {
+        return sseEmitterService.subscribe(deviceId);
+    }
+}

--- a/src/main/java/com/smartfarm/server/dto/SsePayloadDto.java
+++ b/src/main/java/com/smartfarm/server/dto/SsePayloadDto.java
@@ -1,0 +1,20 @@
+package com.smartfarm.server.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * SSE로 클라이언트에게 실시간 전송하는 센서 데이터 페이로드
+ */
+@Getter
+@Builder
+public class SsePayloadDto {
+    private String deviceId;
+    private double temperature;
+    private double humidity;
+    private LocalDateTime timestamp;
+    private boolean coolingFanOn;
+    private boolean heaterOn;
+}

--- a/src/main/java/com/smartfarm/server/service/SensorService.java
+++ b/src/main/java/com/smartfarm/server/service/SensorService.java
@@ -2,6 +2,7 @@ package com.smartfarm.server.service;
 
 import com.smartfarm.server.dto.SensorRequestDto;
 import com.smartfarm.server.dto.SensorResponseDto;
+import com.smartfarm.server.dto.SsePayloadDto;
 import com.smartfarm.server.entity.ControlEventLog;
 import com.smartfarm.server.entity.DeviceConfig;
 import com.smartfarm.server.entity.SensorData;
@@ -25,6 +26,7 @@ public class SensorService {
     private final DeviceConfigService deviceConfigService;
     private final ControlEventLogRepository controlEventLogRepository;
     private final DiscordNotificationService discordNotificationService;
+    private final SseEmitterService sseEmitterService;
 
     // application.yaml에서 유효성 검사 기준값을 가져옵니다.
     @Value("${smartfarm.sensor.validation.temp-min}")
@@ -80,7 +82,17 @@ public class SensorService {
             discordNotificationService.sendMessage(discordMsg);
         }
 
-        // 6. 응답 반환
+        // 6. SSE로 실시간 데이터 push
+        sseEmitterService.sendToDevice(sensorData.getDeviceId(), SsePayloadDto.builder()
+                .deviceId(sensorData.getDeviceId())
+                .temperature(sensorData.getTemperature())
+                .humidity(sensorData.getHumidity())
+                .timestamp(sensorData.getTimestamp())
+                .coolingFanOn(needCooling)
+                .heaterOn(needHeater)
+                .build());
+
+        // 7. 응답 반환
         return SensorResponseDto.builder()
                 .status("SUCCESS")
                 .message("Data processed successfully")

--- a/src/main/java/com/smartfarm/server/service/SseEmitterService.java
+++ b/src/main/java/com/smartfarm/server/service/SseEmitterService.java
@@ -1,0 +1,72 @@
+package com.smartfarm.server.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Slf4j
+@Service
+public class SseEmitterService {
+
+    // deviceId → 연결된 emitter 목록 (다중 브라우저 탭 지원)
+    private final Map<String, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    private static final long TIMEOUT_MS = 30 * 60 * 1000L; // 30분
+
+    /**
+     * 클라이언트가 특정 기기를 구독할 때 호출됩니다.
+     */
+    public SseEmitter subscribe(String deviceId) {
+        SseEmitter emitter = new SseEmitter(TIMEOUT_MS);
+
+        emitters.computeIfAbsent(deviceId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+        log.info("[SSE] {} 기기 구독 시작 (현재 구독자: {}명)", deviceId, emitters.get(deviceId).size());
+
+        // 연결 종료/타임아웃/에러 시 자동 제거
+        Runnable cleanup = () -> removeEmitter(deviceId, emitter);
+        emitter.onCompletion(cleanup);
+        emitter.onTimeout(cleanup);
+        emitter.onError(e -> cleanup.run());
+
+        // 연결 직후 dummy 이벤트로 연결 확인
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("connected"));
+        } catch (IOException e) {
+            removeEmitter(deviceId, emitter);
+        }
+
+        return emitter;
+    }
+
+    /**
+     * 특정 기기를 구독 중인 모든 클라이언트에게 데이터를 전송합니다.
+     */
+    public void sendToDevice(String deviceId, Object data) {
+        List<SseEmitter> deviceEmitters = emitters.get(deviceId);
+        if (deviceEmitters == null || deviceEmitters.isEmpty()) return;
+
+        deviceEmitters.removeIf(emitter -> {
+            try {
+                emitter.send(SseEmitter.event().name("sensor").data(data));
+                return false;
+            } catch (IOException e) {
+                log.debug("[SSE] {} 기기 emitter 전송 실패, 제거합니다.", deviceId);
+                return true;
+            }
+        });
+    }
+
+    private void removeEmitter(String deviceId, SseEmitter emitter) {
+        List<SseEmitter> deviceEmitters = emitters.get(deviceId);
+        if (deviceEmitters != null) {
+            deviceEmitters.remove(emitter);
+            log.info("[SSE] {} 기기 구독 종료 (남은 구독자: {}명)", deviceId, deviceEmitters.size());
+        }
+    }
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -649,10 +649,59 @@
         document.getElementById('lastUpdated').textContent = `마지막 갱신: ${now}`;
     }
 
+    // ─── SSE 연결 관리 ───────────────────────────────────────────
+    let eventSource = null;
+
+    function connectSSE(deviceId) {
+        if (eventSource) {
+            eventSource.close();
+            eventSource = null;
+        }
+        eventSource = new EventSource(`/api/sse/subscribe?deviceId=${encodeURIComponent(deviceId)}`);
+
+        eventSource.addEventListener('connect', function () {
+            console.log('[SSE] 연결 완료:', deviceId);
+        });
+
+        eventSource.addEventListener('sensor', function (e) {
+            const data = JSON.parse(e.data);
+            pushChartData(data);
+            document.getElementById('lastUpdated').textContent =
+                `마지막 갱신: ${new Date().toLocaleTimeString('ko-KR')}`;
+        });
+
+        eventSource.onerror = function () {
+            console.warn('[SSE] 연결 오류 - 브라우저가 자동 재연결합니다.');
+        };
+    }
+
+    function pushChartData(data) {
+        const label = formatTime(data.timestamp);
+
+        temperatureChart.data.labels.push(label);
+        temperatureChart.data.datasets[0].data.push(parseFloat(data.temperature).toFixed(1));
+        if (temperatureChart.data.labels.length > MAX_DATA_POINTS) {
+            temperatureChart.data.labels.shift();
+            temperatureChart.data.datasets[0].data.shift();
+        }
+        temperatureChart.update();
+
+        humidityChart.data.labels.push(label);
+        humidityChart.data.datasets[0].data.push(parseFloat(data.humidity).toFixed(1));
+        if (humidityChart.data.labels.length > MAX_DATA_POINTS) {
+            humidityChart.data.labels.shift();
+            humidityChart.data.datasets[0].data.shift();
+        }
+        humidityChart.update();
+    }
+
     // ─── 기기 변경 이벤트 ────────────────────────────────────────
     document.getElementById('deviceSelect').addEventListener('change', function () {
         currentDeviceId = this.value;
-        refreshAll();
+        loadHistory();
+        loadStatistics();
+        loadEventLogs();
+        connectSSE(currentDeviceId);
     });
 
     // ─── 기기 목록 동적 로드 ─────────────────────────────────────
@@ -743,10 +792,10 @@
         humidityChart = createChart('humidityChart', '습도 (%)', '#34d399');
 
         await loadDevices();
-        if (currentDeviceId) refreshAll();
-
-        // 60초마다 자동 갱신
-        setInterval(() => { if (currentDeviceId) refreshAll(); }, 60000);
+        if (currentDeviceId) {
+            await Promise.all([loadHistory(), loadStatistics(), loadEventLogs()]);
+            connectSSE(currentDeviceId);
+        }
     });
 </script>
 


### PR DESCRIPTION
## Summary
- `SseEmitterService`: deviceId별 emitter 목록 관리 (다중 탭 지원), 구독/전송/정리 처리
- `SseController`: `GET /api/sse/subscribe` — `text/event-stream` 응답, 기기별 실시간 스트림
- `SsePayloadDto`: SSE로 전송하는 페이로드 (온도, 습도, 쿨링팬/히터 상태, 타임스탬프)
- `SensorService`: 센서 데이터 처리 후 `sseEmitterService.sendToDevice()` 호출
- `dashboard.html`: 60초 `setInterval` 폴링 제거 → `EventSource` 기반 실시간 수신으로 교체

## Test plan
- [ ] `/api/sensor` 에 데이터 전송 시 대시보드 그래프가 즉시 업데이트되는지 확인
- [ ] 기기 셀렉터 변경 시 이전 SSE 연결이 닫히고 새 연결이 열리는지 확인
- [ ] 다중 브라우저 탭에서 동시 구독 시 모두 데이터 수신 확인
- [ ] 연결 끊김 후 브라우저 자동 재연결 동작 확인