### PR TITLE
feat: Phase 3 - 기기 등록/삭제, CSV/Excel 내보내기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	// Swagger (Springdoc OpenAPI) 라이브러리 추가
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
+	// Apache POI (Excel .xlsx 내보내기)
+	implementation 'org.apache.poi:poi-ooxml:5.2.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/smartfarm/server/controller/DashboardPageController.java
+++ b/src/main/java/com/smartfarm/server/controller/DashboardPageController.java
@@ -2,9 +2,12 @@ package com.smartfarm.server.controller;
 
 import com.smartfarm.server.entity.ControlEventLog;
 import com.smartfarm.server.service.DashboardService;
+import com.smartfarm.server.service.ExportService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Controller
@@ -20,6 +25,7 @@ import java.util.List;
 public class DashboardPageController {
 
     private final DashboardService dashboardService;
+    private final ExportService exportService;
 
     /**
      * 대시보드 메인 페이지 반환
@@ -53,5 +59,23 @@ public class DashboardPageController {
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<ControlEventLog> result = dashboardService.getControlEventLogs(deviceId, pageRequest);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/export/csv")
+    public void exportCsv(
+            @RequestParam String deviceId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            HttpServletResponse response) throws IOException {
+        exportService.exportCsv(deviceId, start, end, response);
+    }
+
+    @GetMapping("/export/excel")
+    public void exportExcel(
+            @RequestParam String deviceId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            HttpServletResponse response) throws IOException {
+        exportService.exportExcel(deviceId, start, end, response);
     }
 }

--- a/src/main/java/com/smartfarm/server/repository/DeviceConfigRepository.java
+++ b/src/main/java/com/smartfarm/server/repository/DeviceConfigRepository.java
@@ -2,9 +2,14 @@ package com.smartfarm.server.repository;
 
 import com.smartfarm.server.entity.DeviceConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DeviceConfigRepository extends JpaRepository<DeviceConfig, Long> {
     Optional<DeviceConfig> findByDeviceId(String deviceId);
+
+    @Query("SELECT d.deviceId FROM DeviceConfig d ORDER BY d.deviceId ASC")
+    List<String> findAllDeviceIds();
 }

--- a/src/main/java/com/smartfarm/server/repository/SensorHistoryRepository.java
+++ b/src/main/java/com/smartfarm/server/repository/SensorHistoryRepository.java
@@ -28,6 +28,10 @@ public interface SensorHistoryRepository extends JpaRepository<SensorHistory, Lo
     @Query("SELECT DISTINCT s.deviceId FROM SensorHistory s ORDER BY s.deviceId ASC")
     List<String> findDistinctDeviceIds();
 
+    // 특정 기간 내 특정 기기 데이터를 시간 오름차순으로 전체 조회 (내보내기용)
+    List<SensorHistory> findByDeviceIdAndTimestampBetweenOrderByTimestampAsc(
+            String deviceId, LocalDateTime start, LocalDateTime end);
+
     // 1개월 이상 지난 데이터 삭제 (데이터 보존 정책)
     void deleteByTimestampBefore(LocalDateTime cutoff);
 }

--- a/src/main/java/com/smartfarm/server/service/DashboardService.java
+++ b/src/main/java/com/smartfarm/server/service/DashboardService.java
@@ -4,6 +4,7 @@ import com.smartfarm.server.dto.SensorHistoryResponseDto;
 import com.smartfarm.server.dto.SensorStatisticsDto;
 import com.smartfarm.server.entity.ControlEventLog;
 import com.smartfarm.server.repository.ControlEventLogRepository;
+import com.smartfarm.server.repository.DeviceConfigRepository;
 import com.smartfarm.server.repository.SensorHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,12 +23,13 @@ public class DashboardService {
 
     private final SensorHistoryRepository historyRepository;
     private final ControlEventLogRepository eventLogRepository;
+    private final DeviceConfigRepository deviceConfigRepository;
 
     /**
-     * 실제 데이터를 전송한 기기 ID 목록을 중복 없이 조회합니다. (대시보드 셀렉터용)
+     * 등록된 기기 ID 목록을 조회합니다. (대시보드 셀렉터용)
      */
     public List<String> getDeviceIds() {
-        return historyRepository.findDistinctDeviceIds();
+        return deviceConfigRepository.findAllDeviceIds();
     }
 
     /**

--- a/src/main/java/com/smartfarm/server/service/ExportService.java
+++ b/src/main/java/com/smartfarm/server/service/ExportService.java
@@ -1,0 +1,77 @@
+package com.smartfarm.server.service;
+
+import com.smartfarm.server.entity.SensorHistory;
+import com.smartfarm.server.repository.SensorHistoryRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExportService {
+
+    private final SensorHistoryRepository historyRepository;
+
+    public void exportCsv(String deviceId, LocalDateTime start, LocalDateTime end,
+                          HttpServletResponse response) throws IOException {
+        List<SensorHistory> rows = historyRepository
+                .findByDeviceIdAndTimestampBetweenOrderByTimestampAsc(deviceId, start, end);
+
+        response.setContentType("text/csv; charset=UTF-8");
+        response.setHeader("Content-Disposition",
+                "attachment; filename=\"" + deviceId + "_export.csv\"");
+        // UTF-8 BOM: Excel에서 한글 깨짐 방지
+        response.getOutputStream().write(new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF});
+
+        PrintWriter writer = response.getWriter();
+        writer.println("ID,기기ID,온도(°C),습도(%),측정시각");
+        for (SensorHistory h : rows) {
+            writer.printf("%d,%s,%.1f,%.1f,%s%n",
+                    h.getId(), h.getDeviceId(),
+                    h.getTemperature(), h.getHumidity(),
+                    h.getTimestamp().toString());
+        }
+    }
+
+    public void exportExcel(String deviceId, LocalDateTime start, LocalDateTime end,
+                            HttpServletResponse response) throws IOException {
+        List<SensorHistory> rows = historyRepository
+                .findByDeviceIdAndTimestampBetweenOrderByTimestampAsc(deviceId, start, end);
+
+        response.setContentType(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition",
+                "attachment; filename=\"" + deviceId + "_export.xlsx\"");
+
+        try (Workbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("센서 이력");
+
+            Row header = sheet.createRow(0);
+            String[] cols = {"ID", "기기ID", "온도(°C)", "습도(%)", "측정시각"};
+            for (int i = 0; i < cols.length; i++) {
+                header.createCell(i).setCellValue(cols[i]);
+            }
+
+            int rowNum = 1;
+            for (SensorHistory h : rows) {
+                Row row = sheet.createRow(rowNum++);
+                row.createCell(0).setCellValue(h.getId());
+                row.createCell(1).setCellValue(h.getDeviceId());
+                row.createCell(2).setCellValue(h.getTemperature());
+                row.createCell(3).setCellValue(h.getHumidity());
+                row.createCell(4).setCellValue(h.getTimestamp().toString());
+            }
+
+            wb.write(response.getOutputStream());
+        }
+    }
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -169,6 +169,28 @@
 
         .btn-cancel:hover { background: #334155; }
 
+        .btn-add {
+            background: #0369a1;
+            border: none;
+            color: #e2e8f0;
+            padding: 6px 14px;
+            border-radius: 6px;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+        .btn-add:hover { background: #0284c7; }
+
+        .btn-danger {
+            background: transparent;
+            border: 1px solid #ef4444;
+            color: #ef4444;
+            padding: 4px 10px;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            cursor: pointer;
+        }
+        .btn-danger:hover { background: #3f1515; }
+
         .status-dot {
             width: 8px;
             height: 8px;
@@ -377,12 +399,41 @@
             <div class="status-dot"></div>
             <span id="lastUpdated">연결 중...</span>
         </div>
+        <button class="header-btn" onclick="openDeviceManagerModal()">&#43; 기기 관리</button>
         <button class="header-btn btn-config" onclick="openConfigModal()">&#9881; 기기 설정</button>
         <form th:action="@{/logout}" method="POST" style="margin:0;">
             <button type="submit" class="header-btn">로그아웃</button>
         </form>
     </div>
 </header>
+
+<!-- 기기 관리 모달 -->
+<div class="modal-overlay" id="deviceManagerModal">
+    <div class="modal-box" style="max-width: 500px;">
+        <h3>&#43; 기기 관리</h3>
+        <div style="margin-bottom:20px; padding-bottom:16px; border-bottom:1px solid #334155;">
+            <div class="modal-field">
+                <label>기기 ID</label>
+                <input type="text" id="newDeviceId" placeholder="예: SENSOR-002">
+            </div>
+            <div class="modal-field">
+                <label>고온 임계값 (°C)</label>
+                <input type="number" id="newTempThreshold" step="0.1" min="0" value="40">
+            </div>
+            <div class="modal-field">
+                <label>고습 임계값 (%)</label>
+                <input type="number" id="newHumidityThreshold" step="0.1" min="0" value="80">
+            </div>
+            <div id="registerMessage" style="font-size:0.8rem; min-height:18px; margin-bottom:10px;"></div>
+            <button class="btn-add" onclick="registerDevice()">등록</button>
+        </div>
+        <div style="font-size:0.8rem; color:#64748b; margin-bottom:10px;">등록된 기기</div>
+        <div id="registeredDeviceList" style="max-height:200px; overflow-y:auto;"></div>
+        <div class="modal-actions">
+            <button class="btn-cancel" onclick="closeDeviceManagerModal()">닫기</button>
+        </div>
+    </div>
+</div>
 
 <!-- 기기 설정 모달 -->
 <div class="modal-overlay" id="configModal">
@@ -453,6 +504,23 @@
             <div class="chart-container">
                 <canvas id="humidityChart"></canvas>
             </div>
+        </div>
+    </div>
+
+    <!-- 센서 이력 내보내기 -->
+    <div class="log-card" style="margin-bottom:16px;">
+        <div class="section-header">
+            <h3>&#8595; 센서 이력 내보내기</h3>
+        </div>
+        <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+            <label style="font-size:0.8rem; color:#64748b;">시작</label>
+            <input type="datetime-local" id="exportStart"
+                   style="background:#0f172a; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+            <label style="font-size:0.8rem; color:#64748b;">종료</label>
+            <input type="datetime-local" id="exportEnd"
+                   style="background:#0f172a; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+            <button class="refresh-btn" onclick="exportData('csv')">CSV 다운로드</button>
+            <button class="refresh-btn" onclick="exportData('excel')">Excel 다운로드</button>
         </div>
     </div>
 
@@ -647,6 +715,105 @@
         await Promise.all([loadHistory(), loadStatistics(), loadEventLogs()]);
         const now = new Date().toLocaleTimeString('ko-KR');
         document.getElementById('lastUpdated').textContent = `마지막 갱신: ${now}`;
+    }
+
+    // ─── 기기 관리 모달 ──────────────────────────────────────────
+    async function openDeviceManagerModal() {
+        document.getElementById('registerMessage').textContent = '';
+        await loadRegisteredDevices();
+        document.getElementById('deviceManagerModal').classList.add('active');
+    }
+
+    function closeDeviceManagerModal() {
+        document.getElementById('deviceManagerModal').classList.remove('active');
+    }
+
+    async function loadRegisteredDevices() {
+        const container = document.getElementById('registeredDeviceList');
+        try {
+            const res = await fetch('/api/device-config');
+            const configs = await res.json();
+            if (configs.length === 0) {
+                container.innerHTML = '<div style="color:#475569; font-size:0.85rem; padding:8px 0;">등록된 기기가 없습니다.</div>';
+                return;
+            }
+            container.innerHTML = configs.map(c => `
+                <div style="display:flex; justify-content:space-between; align-items:center;
+                            padding:8px 0; border-bottom:1px solid #334155;">
+                    <span style="font-size:0.9rem;">${c.deviceId}</span>
+                    <button class="btn-danger" onclick="deleteDevice('${c.deviceId}')">삭제</button>
+                </div>
+            `).join('');
+        } catch (e) {
+            container.innerHTML = '<div style="color:#f87171; font-size:0.85rem;">목록 로드 실패</div>';
+        }
+    }
+
+    async function registerDevice() {
+        const deviceId = document.getElementById('newDeviceId').value.trim();
+        const tempThreshold = parseFloat(document.getElementById('newTempThreshold').value);
+        const humidityThreshold = parseFloat(document.getElementById('newHumidityThreshold').value);
+        const msgEl = document.getElementById('registerMessage');
+
+        if (!deviceId) {
+            msgEl.style.color = '#f87171';
+            msgEl.textContent = '기기 ID를 입력해주세요.';
+            return;
+        }
+        try {
+            const res = await fetch('/api/device-config', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ deviceId, temperatureThresholdHigh: tempThreshold,
+                                       humidityThresholdHigh: humidityThreshold })
+            });
+            if (res.ok) {
+                msgEl.style.color = '#22c55e';
+                msgEl.textContent = '등록되었습니다.';
+                document.getElementById('newDeviceId').value = '';
+                await loadRegisteredDevices();
+                await loadDevices();
+            } else {
+                msgEl.style.color = '#f87171';
+                msgEl.textContent = '등록에 실패했습니다. (이미 존재하는 기기 ID일 수 있습니다.)';
+            }
+        } catch (e) {
+            msgEl.style.color = '#f87171';
+            msgEl.textContent = '오류가 발생했습니다.';
+        }
+    }
+
+    async function deleteDevice(deviceId) {
+        if (!confirm(`'${deviceId}' 기기를 삭제하시겠습니까?\n관련 임계값 설정이 삭제됩니다.`)) return;
+        try {
+            const res = await fetch(`/api/device-config/${encodeURIComponent(deviceId)}`, {
+                method: 'DELETE'
+            });
+            if (res.ok) {
+                await loadRegisteredDevices();
+                await loadDevices();
+            } else {
+                alert('삭제에 실패했습니다.');
+            }
+        } catch (e) {
+            alert('오류가 발생했습니다.');
+        }
+    }
+
+    document.getElementById('deviceManagerModal').addEventListener('click', function(e) {
+        if (e.target === this) closeDeviceManagerModal();
+    });
+
+    // ─── 데이터 내보내기 ─────────────────────────────────────────
+    function exportData(format) {
+        if (!currentDeviceId) { alert('기기를 먼저 선택해주세요.'); return; }
+        const start = document.getElementById('exportStart').value;
+        const end   = document.getElementById('exportEnd').value;
+        if (!start || !end) { alert('날짜 범위를 입력해주세요.'); return; }
+        const url = `/dashboard/export/${format}?deviceId=${encodeURIComponent(currentDeviceId)}`
+                  + `&start=${encodeURIComponent(start + ':00')}`
+                  + `&end=${encodeURIComponent(end + ':00')}`;
+        window.location.href = url;
     }
 
     // ─── SSE 연결 관리 ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **기기 관리**: 대시보드에서 기기 등록/삭제 가능. 기기 목록 소스를 SensorHistory → DeviceConfig 기반으로 변경해 명시적으로 등록된 기기만 표시
- **CSV/Excel 내보내기**: 날짜 범위 선택 후 센서 이력 다운로드. CSV는 UTF-8 BOM 포함(한글 깨짐 방지), Excel은 .xlsx 형식
- **Apache POI 5.2.5** 의존성 추가

## Test plan
- [ ] 기기 관리 모달에서 새 기기 등록 후 셀렉터에 반영되는지 확인
- [ ] 기기 삭제 후 셀렉터에서 제거되는지 확인
- [ ] 날짜 범위 지정 후 CSV 다운로드 시 한글 정상 표시 확인
- [ ] Excel 다운로드 후 .xlsx 파일 정상 열림 확인