### PR TITLE
feat: 기기 설정 모달 삭제 통합 + 센서 이력 소프트 딜리트

### DIFF
--- a/src/main/java/com/smartfarm/server/entity/SensorHistory.java
+++ b/src/main/java/com/smartfarm/server/entity/SensorHistory.java
@@ -32,6 +32,9 @@ public class SensorHistory {
     @Column(nullable = false)
     private LocalDateTime timestamp;
 
+    @Column
+    private LocalDateTime deletedAt;
+
     @Builder
     public SensorHistory(String deviceId, double temperature, double humidity, LocalDateTime timestamp) {
         this.deviceId = deviceId;

--- a/src/main/java/com/smartfarm/server/repository/SensorHistoryRepository.java
+++ b/src/main/java/com/smartfarm/server/repository/SensorHistoryRepository.java
@@ -4,7 +4,9 @@ import com.smartfarm.server.entity.SensorHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -16,22 +18,32 @@ import java.util.List;
  */
 @Repository
 public interface SensorHistoryRepository extends JpaRepository<SensorHistory, Long>, SensorHistoryRepositoryCustom {
-    
-    // 특정 디바이스의 데이터를 시간 내림차순(최신순)으로 페이징하여 조회
-    Page<SensorHistory> findByDeviceIdOrderByTimestampDesc(String deviceId, Pageable pageable);
-    
-    // 특정 기간 동안의 특정 디바이스 데이터를 조회 (예: 오늘 하루치 데이터)
-    Page<SensorHistory> findByDeviceIdAndTimestampBetweenOrderByTimestampDesc(
+
+    // 특정 디바이스의 데이터를 시간 내림차순(최신순)으로 페이징하여 조회 (소프트 삭제 제외)
+    Page<SensorHistory> findByDeviceIdAndDeletedAtIsNullOrderByTimestampDesc(String deviceId, Pageable pageable);
+
+    // 특정 기간 동안의 특정 디바이스 데이터를 조회 (소프트 삭제 제외)
+    Page<SensorHistory> findByDeviceIdAndTimestampBetweenAndDeletedAtIsNullOrderByTimestampDesc(
             String deviceId, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
-    // 실제 데이터를 전송한 기기 ID 목록을 중복 없이 조회 (대시보드 셀렉터용)
-    @Query("SELECT DISTINCT s.deviceId FROM SensorHistory s ORDER BY s.deviceId ASC")
+    // 실제 데이터를 전송한 기기 ID 목록을 중복 없이 조회 (소프트 삭제 제외)
+    @Query("SELECT DISTINCT s.deviceId FROM SensorHistory s WHERE s.deletedAt IS NULL ORDER BY s.deviceId ASC")
     List<String> findDistinctDeviceIds();
 
-    // 특정 기간 내 특정 기기 데이터를 시간 오름차순으로 전체 조회 (내보내기용)
-    List<SensorHistory> findByDeviceIdAndTimestampBetweenOrderByTimestampAsc(
+    // 특정 기간 내 특정 기기 데이터를 시간 오름차순으로 전체 조회 (내보내기용, 소프트 삭제 제외)
+    List<SensorHistory> findByDeviceIdAndTimestampBetweenAndDeletedAtIsNullOrderByTimestampAsc(
             String deviceId, LocalDateTime start, LocalDateTime end);
 
     // 1개월 이상 지난 데이터 삭제 (데이터 보존 정책)
     void deleteByTimestampBefore(LocalDateTime cutoff);
+
+    // 기기 삭제 시 관련 데이터 소프트 딜리트
+    @Modifying
+    @Query("UPDATE SensorHistory s SET s.deletedAt = :deletedAt WHERE s.deviceId = :deviceId AND s.deletedAt IS NULL")
+    void softDeleteByDeviceId(@Param("deviceId") String deviceId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    // 소프트 딜리트된 지 1주일 이상 지난 데이터 하드 삭제
+    @Modifying
+    @Query("DELETE FROM SensorHistory s WHERE s.deletedAt IS NOT NULL AND s.deletedAt < :cutoff")
+    void deleteByDeletedAtBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/smartfarm/server/repository/SensorHistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/smartfarm/server/repository/SensorHistoryRepositoryCustomImpl.java
@@ -33,9 +33,10 @@ public class SensorHistoryRepositoryCustomImpl implements SensorHistoryRepositor
                 ))
                 .from(sensorHistory)
                 .where(
-                        // WHERE device_id = ? AND timestamp BETWEEN ? AND ?
+                        // WHERE device_id = ? AND timestamp BETWEEN ? AND ? AND deleted_at IS NULL
                         sensorHistory.deviceId.eq(deviceId),
-                        sensorHistory.timestamp.between(start, end)
+                        sensorHistory.timestamp.between(start, end),
+                        sensorHistory.deletedAt.isNull()
                 )
                 .groupBy(sensorHistory.deviceId) // 디바이스별로 묶어서 통계를 냅니다.
                 .fetchOne(); // 결과가 1건(또는 null)이므로 fetchOne()을 사용합니다.

--- a/src/main/java/com/smartfarm/server/service/DashboardService.java
+++ b/src/main/java/com/smartfarm/server/service/DashboardService.java
@@ -36,7 +36,7 @@ public class DashboardService {
      * 특정 기기의 최근 이력 데이터를 페이징하여 조회합니다.
      */
     public Page<SensorHistoryResponseDto> getSensorHistory(String deviceId, Pageable pageable) {
-        return historyRepository.findByDeviceIdOrderByTimestampDesc(deviceId, pageable)
+        return historyRepository.findByDeviceIdAndDeletedAtIsNullOrderByTimestampDesc(deviceId, pageable)
                 .map(SensorHistoryResponseDto::from);
     }
 

--- a/src/main/java/com/smartfarm/server/service/DataBatchService.java
+++ b/src/main/java/com/smartfarm/server/service/DataBatchService.java
@@ -108,4 +108,17 @@ public class DataBatchService {
         mysqlRepository.deleteByTimestampBefore(cutoff);
         log.info("[BATCH TASK] 1개월 이상 지난 SensorHistory 데이터 삭제 완료");
     }
+
+    /**
+     * 매일 새벽 3시에 소프트 딜리트된 지 1주일 이상 지난 SensorHistory 데이터를 하드 딜리트합니다.
+     * 기기 삭제 후 1주일간 데이터를 보존하는 정책 처리
+     */
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * *")
+    public void hardDeleteSoftDeletedHistory() {
+        LocalDateTime cutoff = LocalDateTime.now().minusWeeks(1);
+        log.info("[BATCH TASK] 소프트 딜리트 데이터 정리 실행 - {} 이전 소프트 딜리트 데이터 하드 딜리트 시작", cutoff);
+        mysqlRepository.deleteByDeletedAtBefore(cutoff);
+        log.info("[BATCH TASK] 소프트 딜리트된 지 1주일 이상 지난 SensorHistory 데이터 하드 딜리트 완료");
+    }
 }

--- a/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
+++ b/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
@@ -6,6 +6,7 @@ import com.smartfarm.server.entity.DeviceConfig;
 import com.smartfarm.server.exception.CustomException;
 import com.smartfarm.server.exception.ErrorCode;
 import com.smartfarm.server.repository.DeviceConfigRepository;
+import com.smartfarm.server.repository.SensorHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -22,6 +24,7 @@ import java.util.List;
 public class DeviceConfigService {
 
     private final DeviceConfigRepository deviceConfigRepository;
+    private final SensorHistoryRepository sensorHistoryRepository;
 
     @Value("${smartfarm.sensor.default-temp-threshold}")
     private double defaultTempThreshold;
@@ -85,5 +88,9 @@ public class DeviceConfigService {
                 .orElseThrow(() -> new CustomException(ErrorCode.DEVICE_NOT_FOUND));
         log.info(">>> 기기 설정 삭제 및 캐시 삭제: {}", deviceId);
         deviceConfigRepository.delete(config);
+
+        // 관련 센서 이력 데이터 소프트 딜리트 (1주일 후 하드 딜리트 스케줄러가 처리)
+        sensorHistoryRepository.softDeleteByDeviceId(deviceId, LocalDateTime.now());
+        log.info(">>> {}의 센서 이력 데이터 소프트 딜리트 완료 (1주일 후 자동 삭제)", deviceId);
     }
 }

--- a/src/main/java/com/smartfarm/server/service/ExportService.java
+++ b/src/main/java/com/smartfarm/server/service/ExportService.java
@@ -24,7 +24,7 @@ public class ExportService {
     public void exportCsv(String deviceId, LocalDateTime start, LocalDateTime end,
                           HttpServletResponse response) throws IOException {
         List<SensorHistory> rows = historyRepository
-                .findByDeviceIdAndTimestampBetweenOrderByTimestampAsc(deviceId, start, end);
+                .findByDeviceIdAndTimestampBetweenAndDeletedAtIsNullOrderByTimestampAsc(deviceId, start, end);
 
         response.setContentType("text/csv; charset=UTF-8");
         response.setHeader("Content-Disposition",
@@ -45,7 +45,7 @@ public class ExportService {
     public void exportExcel(String deviceId, LocalDateTime start, LocalDateTime end,
                             HttpServletResponse response) throws IOException {
         List<SensorHistory> rows = historyRepository
-                .findByDeviceIdAndTimestampBetweenOrderByTimestampAsc(deviceId, start, end);
+                .findByDeviceIdAndTimestampBetweenAndDeletedAtIsNullOrderByTimestampAsc(deviceId, start, end);
 
         response.setContentType(
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -399,41 +399,12 @@
             <div class="status-dot"></div>
             <span id="lastUpdated">연결 중...</span>
         </div>
-        <button class="header-btn" onclick="openDeviceManagerModal()">&#43; 기기 관리</button>
         <button class="header-btn btn-config" onclick="openConfigModal()">&#9881; 기기 설정</button>
         <form th:action="@{/logout}" method="POST" style="margin:0;">
             <button type="submit" class="header-btn">로그아웃</button>
         </form>
     </div>
 </header>
-
-<!-- 기기 관리 모달 -->
-<div class="modal-overlay" id="deviceManagerModal">
-    <div class="modal-box" style="max-width: 500px;">
-        <h3>&#43; 기기 관리</h3>
-        <div style="margin-bottom:20px; padding-bottom:16px; border-bottom:1px solid #334155;">
-            <div class="modal-field">
-                <label>기기 ID</label>
-                <input type="text" id="newDeviceId" placeholder="예: SENSOR-002">
-            </div>
-            <div class="modal-field">
-                <label>고온 임계값 (°C)</label>
-                <input type="number" id="newTempThreshold" step="0.1" min="0" value="40">
-            </div>
-            <div class="modal-field">
-                <label>고습 임계값 (%)</label>
-                <input type="number" id="newHumidityThreshold" step="0.1" min="0" value="80">
-            </div>
-            <div id="registerMessage" style="font-size:0.8rem; min-height:18px; margin-bottom:10px;"></div>
-            <button class="btn-add" onclick="registerDevice()">등록</button>
-        </div>
-        <div style="font-size:0.8rem; color:#64748b; margin-bottom:10px;">등록된 기기</div>
-        <div id="registeredDeviceList" style="max-height:200px; overflow-y:auto;"></div>
-        <div class="modal-actions">
-            <button class="btn-cancel" onclick="closeDeviceManagerModal()">닫기</button>
-        </div>
-    </div>
-</div>
 
 <!-- 기기 설정 모달 -->
 <div class="modal-overlay" id="configModal">
@@ -453,6 +424,7 @@
         </div>
         <div id="configMessage" style="font-size:0.8rem; color:#22c55e; min-height:18px;"></div>
         <div class="modal-actions">
+            <button class="btn-danger" onclick="deleteCurrentDevice()" style="margin-right:auto;">기기 삭제</button>
             <button class="btn-cancel" onclick="closeConfigModal()">취소</button>
             <button class="btn-save" onclick="saveConfig()">저장</button>
         </div>
@@ -717,80 +689,16 @@
         document.getElementById('lastUpdated').textContent = `마지막 갱신: ${now}`;
     }
 
-    // ─── 기기 관리 모달 ──────────────────────────────────────────
-    async function openDeviceManagerModal() {
-        document.getElementById('registerMessage').textContent = '';
-        await loadRegisteredDevices();
-        document.getElementById('deviceManagerModal').classList.add('active');
-    }
-
-    function closeDeviceManagerModal() {
-        document.getElementById('deviceManagerModal').classList.remove('active');
-    }
-
-    async function loadRegisteredDevices() {
-        const container = document.getElementById('registeredDeviceList');
+    // ─── 기기 삭제 ───────────────────────────────────────────────
+    async function deleteCurrentDevice() {
+        if (!currentDeviceId) return;
+        if (!confirm(`'${currentDeviceId}' 기기를 삭제하시겠습니까?\n임계값 설정이 삭제되고, 센서 이력 데이터는 1주일 후 자동으로 삭제됩니다.`)) return;
         try {
-            const res = await fetch('/api/device-config');
-            const configs = await res.json();
-            if (configs.length === 0) {
-                container.innerHTML = '<div style="color:#475569; font-size:0.85rem; padding:8px 0;">등록된 기기가 없습니다.</div>';
-                return;
-            }
-            container.innerHTML = configs.map(c => `
-                <div style="display:flex; justify-content:space-between; align-items:center;
-                            padding:8px 0; border-bottom:1px solid #334155;">
-                    <span style="font-size:0.9rem;">${c.deviceId}</span>
-                    <button class="btn-danger" onclick="deleteDevice('${c.deviceId}')">삭제</button>
-                </div>
-            `).join('');
-        } catch (e) {
-            container.innerHTML = '<div style="color:#f87171; font-size:0.85rem;">목록 로드 실패</div>';
-        }
-    }
-
-    async function registerDevice() {
-        const deviceId = document.getElementById('newDeviceId').value.trim();
-        const tempThreshold = parseFloat(document.getElementById('newTempThreshold').value);
-        const humidityThreshold = parseFloat(document.getElementById('newHumidityThreshold').value);
-        const msgEl = document.getElementById('registerMessage');
-
-        if (!deviceId) {
-            msgEl.style.color = '#f87171';
-            msgEl.textContent = '기기 ID를 입력해주세요.';
-            return;
-        }
-        try {
-            const res = await fetch('/api/device-config', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ deviceId, temperatureThresholdHigh: tempThreshold,
-                                       humidityThresholdHigh: humidityThreshold })
-            });
-            if (res.ok) {
-                msgEl.style.color = '#22c55e';
-                msgEl.textContent = '등록되었습니다.';
-                document.getElementById('newDeviceId').value = '';
-                await loadRegisteredDevices();
-                await loadDevices();
-            } else {
-                msgEl.style.color = '#f87171';
-                msgEl.textContent = '등록에 실패했습니다. (이미 존재하는 기기 ID일 수 있습니다.)';
-            }
-        } catch (e) {
-            msgEl.style.color = '#f87171';
-            msgEl.textContent = '오류가 발생했습니다.';
-        }
-    }
-
-    async function deleteDevice(deviceId) {
-        if (!confirm(`'${deviceId}' 기기를 삭제하시겠습니까?\n관련 임계값 설정이 삭제됩니다.`)) return;
-        try {
-            const res = await fetch(`/api/device-config/${encodeURIComponent(deviceId)}`, {
+            const res = await fetch(`/api/device-config/${encodeURIComponent(currentDeviceId)}`, {
                 method: 'DELETE'
             });
             if (res.ok) {
-                await loadRegisteredDevices();
+                closeConfigModal();
                 await loadDevices();
             } else {
                 alert('삭제에 실패했습니다.');
@@ -799,10 +707,6 @@
             alert('오류가 발생했습니다.');
         }
     }
-
-    document.getElementById('deviceManagerModal').addEventListener('click', function(e) {
-        if (e.target === this) closeDeviceManagerModal();
-    });
 
     // ─── 데이터 내보내기 ─────────────────────────────────────────
     function exportData(format) {


### PR DESCRIPTION
## Summary
- 별도 기기 관리 모달 제거, 기기 설정 모달(⚙ 기기 설정)에 삭제 버튼 통합
- `SensorHistory`에 `deletedAt` 필드 추가 - 기기 삭제 시 즉시 하드 딜리트 대신 소프트 딜리트
- 매일 새벽 3시 스케줄러가 소프트 딜리트된 지 1주일 지난 데이터 자동 하드 딜리트
- 모든 센서 이력 조회 쿼리에 `deletedAt IS NULL` 필터 적용 (소프트 딜리트 데이터 제외)

## Test plan
- [ ] ⚙ 기기 설정 모달 열기 → "기기 삭제" 버튼 확인
- [ ] 삭제 확인 후 DeviceConfig가 DB에서 삭제되고 셀렉터에서 기기가 사라지는지 확인
- [ ] 삭제 후 SensorHistory의 deletedAt 컬럼에 현재 시각이 기록되는지 확인
- [ ] 삭제된 기기의 데이터가 그래프/통계/이벤트 로그에 나타나지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)