### PR TITLE
fix: 내보내기 날짜/시간 입력 UI 개선

### DIFF
--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -385,6 +385,11 @@
             main { padding: 16px; }
             .stats-grid { grid-template-columns: 1fr 1fr; }
         }
+        /* 날짜/시간 입력 기본 아이콘 숨김 */
+        input[type="date"]::-webkit-calendar-picker-indicator,
+        input[type="time"]::-webkit-calendar-picker-indicator {
+            display: none;
+        }
     </style>
 </head>
 <body>
@@ -493,8 +498,12 @@
                     <button onclick="document.getElementById('exportStartDate').showPicker()"
                             style="position:absolute; right:6px; background:none; border:none; cursor:pointer; font-size:1rem; line-height:1; padding:0; color:#94a3b8;">📅</button>
                 </div>
-                <input type="time" id="exportStartTime" value="00:00"
-                       style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+                <div style="position:relative; display:flex; align-items:center;">
+                    <input type="time" id="exportStartTime" value="00:00"
+                           style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 36px 6px 10px; border-radius:6px; font-size:0.85rem; cursor:pointer;">
+                    <button onclick="document.getElementById('exportStartTime').showPicker()"
+                            style="position:absolute; right:6px; background:none; border:none; cursor:pointer; font-size:1rem; line-height:1; padding:0;">⏰</button>
+                </div>
             </div>
             <label style="font-size:0.8rem; color:#64748b;">종료</label>
             <div style="display:flex; align-items:center; gap:4px;">
@@ -504,8 +513,12 @@
                     <button onclick="document.getElementById('exportEndDate').showPicker()"
                             style="position:absolute; right:6px; background:none; border:none; cursor:pointer; font-size:1rem; line-height:1; padding:0; color:#94a3b8;">📅</button>
                 </div>
-                <input type="time" id="exportEndTime" value="23:59"
-                       style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+                <div style="position:relative; display:flex; align-items:center;">
+                    <input type="time" id="exportEndTime" value="23:59"
+                           style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 36px 6px 10px; border-radius:6px; font-size:0.85rem; cursor:pointer;">
+                    <button onclick="document.getElementById('exportEndTime').showPicker()"
+                            style="position:absolute; right:6px; background:none; border:none; cursor:pointer; font-size:1rem; line-height:1; padding:0;">⏰</button>
+                </div>
             </div>
             <button class="refresh-btn" onclick="exportData('csv')">CSV 다운로드</button>
             <button class="refresh-btn" onclick="exportData('excel')">Excel 다운로드</button>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -486,11 +486,27 @@
         </div>
         <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
             <label style="font-size:0.8rem; color:#64748b;">시작</label>
-            <input type="datetime-local" id="exportStart"
-                   style="background:#0f172a; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+            <div style="display:flex; align-items:center; gap:4px;">
+                <div style="position:relative; display:flex; align-items:center;">
+                    <input type="date" id="exportStartDate"
+                           style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 36px 6px 10px; border-radius:6px; font-size:0.85rem; cursor:pointer; appearance:none; -webkit-appearance:none;">
+                    <button onclick="document.getElementById('exportStartDate').showPicker()"
+                            style="position:absolute; right:6px; background:none; border:none; cursor:pointer; font-size:1rem; line-height:1; padding:0; color:#94a3b8;">📅</button>
+                </div>
+                <input type="time" id="exportStartTime" value="00:00"
+                       style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+            </div>
             <label style="font-size:0.8rem; color:#64748b;">종료</label>
-            <input type="datetime-local" id="exportEnd"
-                   style="background:#0f172a; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+            <div style="display:flex; align-items:center; gap:4px;">
+                <div style="position:relative; display:flex; align-items:center;">
+                    <input type="date" id="exportEndDate"
+                           style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 36px 6px 10px; border-radius:6px; font-size:0.85rem; cursor:pointer; appearance:none; -webkit-appearance:none;">
+                    <button onclick="document.getElementById('exportEndDate').showPicker()"
+                            style="position:absolute; right:6px; background:none; border:none; cursor:pointer; font-size:1rem; line-height:1; padding:0; color:#94a3b8;">📅</button>
+                </div>
+                <input type="time" id="exportEndTime" value="23:59"
+                       style="background:#1e293b; border:1px solid #334155; color:#e2e8f0; padding:6px 10px; border-radius:6px; font-size:0.85rem;">
+            </div>
             <button class="refresh-btn" onclick="exportData('csv')">CSV 다운로드</button>
             <button class="refresh-btn" onclick="exportData('excel')">Excel 다운로드</button>
         </div>
@@ -711,12 +727,16 @@
     // ─── 데이터 내보내기 ─────────────────────────────────────────
     function exportData(format) {
         if (!currentDeviceId) { alert('기기를 먼저 선택해주세요.'); return; }
-        const start = document.getElementById('exportStart').value;
-        const end   = document.getElementById('exportEnd').value;
-        if (!start || !end) { alert('날짜 범위를 입력해주세요.'); return; }
+        const startDate = document.getElementById('exportStartDate').value;
+        const startTime = document.getElementById('exportStartTime').value || '00:00';
+        const endDate   = document.getElementById('exportEndDate').value;
+        const endTime   = document.getElementById('exportEndTime').value || '23:59';
+        if (!startDate || !endDate) { alert('날짜 범위를 입력해주세요.'); return; }
+        const start = `${startDate}T${startTime}:00`;
+        const end   = `${endDate}T${endTime}:00`;
         const url = `/dashboard/export/${format}?deviceId=${encodeURIComponent(currentDeviceId)}`
-                  + `&start=${encodeURIComponent(start + ':00')}`
-                  + `&end=${encodeURIComponent(end + ':00')}`;
+                  + `&start=${encodeURIComponent(start)}`
+                  + `&end=${encodeURIComponent(end)}`;
         window.location.href = url;
     }
 
@@ -861,6 +881,11 @@
     document.addEventListener('DOMContentLoaded', async () => {
         temperatureChart = createChart('temperatureChart', '온도 (°C)', '#f87171');
         humidityChart = createChart('humidityChart', '습도 (%)', '#34d399');
+
+        // 내보내기 날짜 기본값: 오늘
+        const today = new Date().toISOString().slice(0, 10);
+        document.getElementById('exportStartDate').value = today;
+        document.getElementById('exportEndDate').value   = today;
 
         await loadDevices();
         if (currentDeviceId) {


### PR DESCRIPTION
## Summary
- `datetime-local` → `date` + `time` 입력 필드 분리
- 브라우저 기본 달력/시계 아이콘 숨김 (`::-webkit-calendar-picker-indicator`)
- 📅 달력 이모지 버튼, ⏰ 시계 이모지 버튼으로 가독성 개선
- 오늘 날짜 기본값 자동 설정

## Test plan
- [ ] 내보내기 섹션 날짜/시간 입력 UI 확인
- [ ] 📅 클릭 시 달력 팝업 동작 확인
- [ ] ⏰ 클릭 시 시간 선택기 동작 확인
- [ ] CSV/Excel 다운로드 정상 동작 확인