### PR TITLE
feat: PC 클라이언트 API 키 인증 기능 구현

### DIFF
--- a/src/main/java/com/smartfarm/server/config/DeviceApiKeyAuthFilter.java
+++ b/src/main/java/com/smartfarm/server/config/DeviceApiKeyAuthFilter.java
@@ -1,0 +1,100 @@
+package com.smartfarm.server.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartfarm.server.exception.ErrorCode;
+import com.smartfarm.server.service.DeviceConfigService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * PC 클라이언트 전용 엔드포인트에 대한 API 키 인증 필터.
+ *
+ * <p>PC 클라이언트는 모든 요청에 다음 두 헤더를 포함해야 합니다:</p>
+ * <ul>
+ *   <li>{@code X-Device-Id} : 기기 고유 ID (예: WINDOWS-PC-01)</li>
+ *   <li>{@code X-Api-Key}   : 기기 등록 시 발급된 UUID 형식의 API 키</li>
+ * </ul>
+ *
+ * <p>헤더가 없거나 값이 일치하지 않으면 HTTP 401 Unauthorized를 반환합니다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeviceApiKeyAuthFilter extends OncePerRequestFilter {
+
+    public static final String HEADER_DEVICE_ID = "X-Device-Id";
+    public static final String HEADER_API_KEY   = "X-Api-Key";
+
+    /** API 키 인증이 필요한 PC 클라이언트 전용 경로 */
+    private static final List<String> PROTECTED_PREFIXES = List.of(
+            "/api/sensor/",
+            "/api/device-control/pending",
+            "/api/device-control/ack",
+            "/api/sse/device-command-stream"
+    );
+
+    private final DeviceConfigService deviceConfigService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+
+        // 보호 대상 경로가 아니면 통과
+        if (!isProtectedPath(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String deviceId = request.getHeader(HEADER_DEVICE_ID);
+        String apiKey   = request.getHeader(HEADER_API_KEY);
+
+        // 헤더 누락 검사
+        if (deviceId == null || deviceId.isBlank() || apiKey == null || apiKey.isBlank()) {
+            log.warn(">>> [API Key Auth] 헤더 누락 — path={}, X-Device-Id={}", path, deviceId);
+            sendUnauthorized(response, "X-Device-Id, X-Api-Key 헤더가 필요합니다.");
+            return;
+        }
+
+        // API 키 유효성 검증
+        if (!deviceConfigService.validateApiKey(deviceId, apiKey)) {
+            log.warn(">>> [API Key Auth] 인증 실패 — deviceId={}, path={}", deviceId, path);
+            sendUnauthorized(response, ErrorCode.INVALID_API_KEY.getMessage());
+            return;
+        }
+
+        log.debug(">>> [API Key Auth] 인증 성공 — deviceId={}, path={}", deviceId, path);
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isProtectedPath(String path) {
+        return PROTECTED_PREFIXES.stream().anyMatch(path::startsWith);
+    }
+
+    private void sendUnauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = Map.of(
+                "status", 401,
+                "code",   ErrorCode.INVALID_API_KEY.getCode(),
+                "message", message
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/smartfarm/server/config/DeviceApiKeyMigrationRunner.java
+++ b/src/main/java/com/smartfarm/server/config/DeviceApiKeyMigrationRunner.java
@@ -1,0 +1,44 @@
+package com.smartfarm.server.config;
+
+import com.smartfarm.server.entity.DeviceConfig;
+import com.smartfarm.server.repository.DeviceConfigRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 기존 DeviceConfig 행 중 apiKey가 NULL인 경우 UUID를 자동 발급합니다.
+ * (apiKey 컬럼이 추가되기 전에 등록된 기기 대상 1회성 마이그레이션)
+ */
+@Slf4j
+@Component
+@Order(2)
+@RequiredArgsConstructor
+public class DeviceApiKeyMigrationRunner implements ApplicationRunner {
+
+    private final DeviceConfigRepository deviceConfigRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        List<DeviceConfig> configs = deviceConfigRepository.findAll();
+        long migrated = configs.stream()
+                .filter(c -> c.getApiKey() == null)
+                .peek(c -> {
+                    c.generateApiKeyIfAbsent();
+                    deviceConfigRepository.save(c);
+                    log.info(">>> [API Key Migration] {} 기기 API 키 자동 발급 완료", c.getDeviceId());
+                })
+                .count();
+
+        if (migrated > 0) {
+            log.info(">>> [API Key Migration] 총 {}개 기기 API 키 마이그레이션 완료", migrated);
+        }
+    }
+}

--- a/src/main/java/com/smartfarm/server/config/SecurityConfig.java
+++ b/src/main/java/com/smartfarm/server/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.smartfarm.server.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -7,10 +8,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final DeviceApiKeyAuthFilter deviceApiKeyAuthFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -19,10 +24,13 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // PC 클라이언트 전용 엔드포인트는 DeviceApiKeyAuthFilter가 API 키를 검증합니다.
+        // Spring Security는 permitAll()로 통과시키되, 필터에서 인증을 강제합니다.
         http
+            .addFilterBefore(deviceApiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/login", "/api/sensor/**").permitAll()
-                // PC 클라이언트 전용 엔드포인트 — 인증 없이 접근 허용
+                // PC 클라이언트 전용 엔드포인트 — Spring Security는 허용, DeviceApiKeyAuthFilter가 API 키 검증
                 .requestMatchers("/api/device-control/pending", "/api/device-control/ack").permitAll()
                 .requestMatchers("/api/sse/device-command-stream").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/smartfarm/server/controller/DeviceConfigController.java
+++ b/src/main/java/com/smartfarm/server/controller/DeviceConfigController.java
@@ -44,4 +44,10 @@ public class DeviceConfigController {
         deviceConfigService.deleteDeviceConfig(deviceId);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "API 키 재발급", description = "기기의 API 키를 새 UUID로 교체합니다. 기존 키는 즉시 무효화됩니다.")
+    @PostMapping("/{deviceId}/regenerate-key")
+    public ResponseEntity<DeviceConfigResponseDto> regenerateApiKey(@PathVariable String deviceId) {
+        return ResponseEntity.ok(deviceConfigService.regenerateApiKey(deviceId));
+    }
 }

--- a/src/main/java/com/smartfarm/server/dto/DeviceConfigResponseDto.java
+++ b/src/main/java/com/smartfarm/server/dto/DeviceConfigResponseDto.java
@@ -12,6 +12,7 @@ public class DeviceConfigResponseDto {
     private String deviceId;
     private double temperatureThresholdHigh;
     private double humidityThresholdHigh;
+    private String apiKey; // PC 클라이언트 인증용 API 키 (대시보드에서만 확인 가능)
 
     public static DeviceConfigResponseDto from(DeviceConfig entity) {
         return DeviceConfigResponseDto.builder()
@@ -19,6 +20,7 @@ public class DeviceConfigResponseDto {
                 .deviceId(entity.getDeviceId())
                 .temperatureThresholdHigh(entity.getTemperatureThresholdHigh())
                 .humidityThresholdHigh(entity.getHumidityThresholdHigh())
+                .apiKey(entity.getApiKey())
                 .build();
     }
 }

--- a/src/main/java/com/smartfarm/server/entity/DeviceConfig.java
+++ b/src/main/java/com/smartfarm/server/entity/DeviceConfig.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
+import java.util.UUID;
 
 @Entity
 @Table(name = "device_config")
@@ -29,6 +30,17 @@ public class DeviceConfig implements Serializable {
     @Column(nullable = false)
     private double humidityThresholdHigh; // 고습 경보 임계치 (추후 확장을 위해 미리 추가)
 
+    @Column(nullable = false, unique = true)
+    private String apiKey; // PC 클라이언트 인증용 API 키 (UUID)
+
+    /** 신규 등록 시 API 키 자동 생성 */
+    @PrePersist
+    public void generateApiKeyIfAbsent() {
+        if (this.apiKey == null) {
+            this.apiKey = UUID.randomUUID().toString();
+        }
+    }
+
     @Builder
     public DeviceConfig(String deviceId, double temperatureThresholdHigh, double humidityThresholdHigh) {
         this.deviceId = deviceId;
@@ -39,5 +51,10 @@ public class DeviceConfig implements Serializable {
     public void update(double temperatureThresholdHigh, double humidityThresholdHigh) {
         this.temperatureThresholdHigh = temperatureThresholdHigh;
         this.humidityThresholdHigh = humidityThresholdHigh;
+    }
+
+    /** API 키 재발급 */
+    public void regenerateApiKey() {
+        this.apiKey = UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/com/smartfarm/server/exception/ErrorCode.java
+++ b/src/main/java/com/smartfarm/server/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "E002", "등록되지 않은 기기입니다."),
     COMMAND_NOT_FOUND(HttpStatus.BAD_REQUEST, "E003", "존재하지 않는 명령입니다."),
     INVALID_COMMAND_TYPE(HttpStatus.BAD_REQUEST, "E004", "유효하지 않은 명령 종류입니다."),
+
+    // 401 Unauthorized
+    INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 API 키입니다. X-Device-Id, X-Api-Key 헤더를 확인하세요."),
     
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
+++ b/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
@@ -93,4 +93,28 @@ public class DeviceConfigService {
         sensorHistoryRepository.softDeleteByDeviceId(deviceId, LocalDateTime.now());
         log.info(">>> {}의 센서 이력 데이터 소프트 딜리트 완료 (1주일 후 자동 삭제)", deviceId);
     }
+
+    /**
+     * PC 클라이언트 API 키 유효성 검증
+     * X-Device-Id, X-Api-Key 헤더 값을 검증합니다.
+     */
+    public boolean validateApiKey(String deviceId, String apiKey) {
+        return deviceConfigRepository.findByDeviceId(deviceId)
+                .map(config -> config.getApiKey() != null && config.getApiKey().equals(apiKey))
+                .orElse(false);
+    }
+
+    /**
+     * API 키 재발급 — 기존 키를 새 UUID로 교체하고 캐시를 무효화합니다.
+     */
+    @Transactional
+    @CacheEvict(value = "deviceConfigObj", key = "#deviceId")
+    public DeviceConfigResponseDto regenerateApiKey(String deviceId) {
+        DeviceConfig config = deviceConfigRepository.findByDeviceId(deviceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DEVICE_NOT_FOUND));
+        config.regenerateApiKey();
+        DeviceConfig saved = deviceConfigRepository.save(config);
+        log.info(">>> {} 기기 API 키 재발급 완료", deviceId);
+        return DeviceConfigResponseDto.from(saved);
+    }
 }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -751,6 +751,23 @@
             <label>고습 임계값 (%)</label>
             <input type="number" id="configHumidityThreshold" step="0.1" min="0" max="100">
         </div>
+        <div class="modal-field">
+            <label>API 키 <span style="font-size:0.7rem; color:#64748b; font-weight:400;">(PC 클라이언트 인증용)</span></label>
+            <div style="display:flex; gap:6px; align-items:center;">
+                <input type="text" id="configApiKey" readonly
+                       style="flex:1; color:#94a3b8; cursor:default; font-family:monospace; font-size:0.78rem; letter-spacing:0.03em;">
+                <button type="button" onclick="copyApiKey()"
+                        title="클립보드에 복사"
+                        style="padding:6px 10px; background:#334155; border:1px solid #475569; border-radius:6px; color:#e2e8f0; cursor:pointer; font-size:0.8rem; white-space:nowrap;">
+                    &#128203; 복사
+                </button>
+                <button type="button" onclick="regenerateApiKey()"
+                        title="API 키 재발급 (기존 키 즉시 무효화)"
+                        style="padding:6px 10px; background:#7c3aed; border:none; border-radius:6px; color:#fff; cursor:pointer; font-size:0.8rem; white-space:nowrap;">
+                    &#128260; 재발급
+                </button>
+            </div>
+        </div>
         <div id="configMessage" style="font-size:0.8rem; color:#22c55e; min-height:18px;"></div>
         <div class="modal-actions">
             <button class="btn-danger" onclick="deleteCurrentDevice()" style="margin-right:auto;">기기 삭제</button>
@@ -1655,12 +1672,14 @@
         if (!currentDeviceId) return;
         document.getElementById('configDeviceId').value = currentDeviceId;
         document.getElementById('configMessage').textContent = '';
+        document.getElementById('configApiKey').value = '';
         try {
             const res = await fetch(`/api/device-config/${encodeURIComponent(currentDeviceId)}`);
             if (res.ok) {
                 const data = await res.json();
                 document.getElementById('configTempThreshold').value = data.temperatureThresholdHigh;
                 document.getElementById('configHumidityThreshold').value = data.humidityThresholdHigh;
+                document.getElementById('configApiKey').value = data.apiKey ?? '(미등록 기기 — 저장 후 발급됩니다)';
             }
         } catch (e) { /* 기본값 유지 */ }
         document.getElementById('configModal').classList.add('active');
@@ -1668,6 +1687,42 @@
 
     function closeConfigModal() {
         document.getElementById('configModal').classList.remove('active');
+    }
+
+    function copyApiKey() {
+        const val = document.getElementById('configApiKey').value;
+        if (!val || val.startsWith('(')) return;
+        navigator.clipboard.writeText(val).then(() => {
+            const msgEl = document.getElementById('configMessage');
+            msgEl.style.color = '#22c55e';
+            msgEl.textContent = 'API 키가 클립보드에 복사되었습니다.';
+            setTimeout(() => { msgEl.textContent = ''; }, 2000);
+        });
+    }
+
+    async function regenerateApiKey() {
+        if (!currentDeviceId) return;
+        const msgEl = document.getElementById('configMessage');
+        if (!confirm(`"${currentDeviceId}" 기기의 API 키를 재발급하시겠습니까?\n기존 키는 즉시 무효화됩니다.`)) return;
+        try {
+            const res = await fetch(`/api/device-config/${encodeURIComponent(currentDeviceId)}/regenerate-key`, {
+                method: 'POST',
+                headers: getCsrfHeaders()
+            });
+            if (res.ok) {
+                const data = await res.json();
+                document.getElementById('configApiKey').value = data.apiKey;
+                msgEl.style.color = '#a78bfa';
+                msgEl.textContent = 'API 키가 재발급되었습니다.';
+                setTimeout(() => { msgEl.textContent = ''; }, 3000);
+            } else {
+                msgEl.style.color = '#f87171';
+                msgEl.textContent = '재발급에 실패했습니다.';
+            }
+        } catch (e) {
+            msgEl.style.color = '#f87171';
+            msgEl.textContent = '오류가 발생했습니다.';
+        }
     }
 
     async function saveConfig() {


### PR DESCRIPTION
## Summary
- `DeviceApiKeyAuthFilter` 신규 추가 — `X-Device-Id` + `X-Api-Key` 헤더로 PC 클라이언트 전용 경로 보호
- `DeviceConfig` 엔티티에 `apiKey` 필드 추가 (`@PrePersist` 자동 발급, `regenerateApiKey()` 지원)
- `DeviceApiKeyMigrationRunner` — 서버 시작 시 기존 NULL apiKey 행 자동 마이그레이션
- 대시보드 configModal에 API 키 표시 + 클립보드 복사 + 재발급 버튼 추가

## Test plan
- [ ] 기기 등록 시 apiKey가 자동 발급되는지 확인
- [ ] X-Device-Id, X-Api-Key 헤더 없이 `/api/sensor/data` 호출 → 401 반환 확인
- [ ] 잘못된 API 키로 호출 → 401 반환 확인
- [ ] 올바른 헤더로 호출 → 정상 통과 확인
- [ ] 대시보드 설정 모달에서 API 키 확인 및 복사 동작 확인
- [ ] 재발급 버튼 클릭 시 새 키로 갱신되는지 확인