### PR TITLE
feat: Discord 알림 쿨다운 기능 추가 (5분 중복 발송 방지)

### DIFF
--- a/src/main/java/com/smartfarm/server/service/DiscordNotificationService.java
+++ b/src/main/java/com/smartfarm/server/service/DiscordNotificationService.java
@@ -1,28 +1,64 @@
 package com.smartfarm.server.service;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * 디스코드 웹훅을 통해 알림 메시지를 발송하는 서비스입니다.
+ *
+ * <p>쿨다운 기능: 같은 기기 + 같은 알림 타입은 {@code cooldownSeconds} 내에
+ * 중복 발송하지 않습니다. Redis TTL 키로 관리합니다.</p>
+ * <p>Redis 키 형식: {@code alert:cooldown:{deviceId}:{alertType}}</p>
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class DiscordNotificationService {
 
     @Value("${smartfarm.notification.discord-webhook-url}")
     private String webhookUrl;
 
+    @Value("${smartfarm.notification.cooldown-seconds}")
+    private long cooldownSeconds;
+
+    private final StringRedisTemplate redisTemplate;
+
     // HTTP 요청을 보내기 위한 RestTemplate 객체 (간단한 동기식 요청에 적합)
     private final RestTemplate restTemplate = new RestTemplate();
+
+    /**
+     * 쿨다운을 적용하여 알림을 발송합니다.
+     * 쿨다운 기간 내 같은 기기/같은 알림 타입이 들어오면 발송을 건너뜁니다.
+     *
+     * @param deviceId  기기 ID
+     * @param alertType 알림 종류 (예: "TEMP", "HUMIDITY")
+     * @param message   전송할 텍스트 메시지
+     */
+    public void sendAlertIfNotCoolingDown(String deviceId, String alertType, String message) {
+        String cooldownKey = String.format("alert:cooldown:%s:%s", deviceId, alertType);
+
+        // setIfAbsent = Redis SET NX EX : 키가 없을 때만 저장 성공(true) → 발송
+        // 키가 이미 있으면 false → 쿨다운 중이므로 스킵
+        Boolean isFirstAlert = redisTemplate.opsForValue()
+                .setIfAbsent(cooldownKey, "1", Duration.ofSeconds(cooldownSeconds));
+
+        if (Boolean.TRUE.equals(isFirstAlert)) {
+            sendMessage(message);
+        } else {
+            log.info("[알림 쿨다운] {} {} 알림 억제 ({}초 내 중복 발송 방지)", deviceId, alertType, cooldownSeconds);
+        }
+    }
 
     /**
      * 디스코드 채널로 메시지를 전송합니다.

--- a/src/main/java/com/smartfarm/server/service/SensorService.java
+++ b/src/main/java/com/smartfarm/server/service/SensorService.java
@@ -64,7 +64,7 @@ public class SensorService {
             deviceControlService.sendAutoCommand(sensorData.getDeviceId(), "COOLING_FAN_ON");
 
             String discordMsg = String.format("🚨 **[스마트팜 경고] %s 쿨링팬 가동!**\n%s", sensorData.getDeviceId(), message);
-            discordNotificationService.sendMessage(discordMsg);
+            discordNotificationService.sendAlertIfNotCoolingDown(sensorData.getDeviceId(), "TEMP", discordMsg);
         }
 
         if (needHumidityControl) {
@@ -75,7 +75,7 @@ public class SensorService {
             deviceControlService.sendAutoCommand(sensorData.getDeviceId(), "HEATER_ON");
 
             String discordMsg = String.format("💧 **[스마트팜 경고] %s 히터 가동!**\n%s", sensorData.getDeviceId(), message);
-            discordNotificationService.sendMessage(discordMsg);
+            discordNotificationService.sendAlertIfNotCoolingDown(sensorData.getDeviceId(), "HUMIDITY", discordMsg);
         }
 
         // 6. SSE로 실시간 데이터 push

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,3 +32,5 @@ smartfarm:
     # 디스코드 웹훅 URL 설정 (실무에서는 이 부분을 application-prod.yaml로 빼고 환경변수 처리하는 것이 안전합니다)
     # 환경변수 DISCORD_WEBHOOK_URL에서 주입 (미설정 시 빈 문자열)
     discord-webhook-url: ${DISCORD_WEBHOOK_URL:}
+    # 같은 기기/같은 종류 알림 재발송 금지 대기 시간 (초). 기본 5분
+    cooldown-seconds: 300


### PR DESCRIPTION
## Summary
- 임계값이 지속 초과돼도 같은 기기/같은 알림 타입은 5분 내 재발송 안 함
- Redis `SET NX EX` (`setIfAbsent`)로 `alert:cooldown:{deviceId}:{alertType}` 키 관리
- 쿨다운 시간 `application.yaml` `cooldown-seconds`로 조정 가능

## Test plan
- [ ] 임계값 초과 시 첫 알림 Discord 발송 확인
- [ ] 5분 내 같은 기기 동일 타입 재요청 → 로그에 "알림 억제" 출력, Discord 미발송 확인
- [ ] 온도/습도는 각각 독립 쿨다운 (하나 억제 중에도 다른 타입은 발송)