### PR TITLE
feat: 일간 Discord 리포트 배치 + ROLE_USER 권한 분리

### DIFF
--- a/src/main/java/com/smartfarm/server/config/AdminUserInitializer.java
+++ b/src/main/java/com/smartfarm/server/config/AdminUserInitializer.java
@@ -28,5 +28,15 @@ public class AdminUserInitializer implements ApplicationRunner {
             userRepository.save(admin);
             log.info(">>> 초기 관리자 계정 생성 완료 (admin / admin1234)");
         }
+
+        if (userRepository.findByUsername("user").isEmpty()) {
+            User user = User.builder()
+                    .username("user")
+                    .password(passwordEncoder.encode("user1234"))
+                    .role("ROLE_USER")
+                    .build();
+            userRepository.save(user);
+            log.info(">>> 초기 일반 사용자 계정 생성 완료 (user / user1234) — 조회 전용");
+        }
     }
 }

--- a/src/main/java/com/smartfarm/server/config/SecurityConfig.java
+++ b/src/main/java/com/smartfarm/server/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.smartfarm.server.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -12,6 +13,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/smartfarm/server/controller/DeviceConfigController.java
+++ b/src/main/java/com/smartfarm/server/controller/DeviceConfigController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -33,12 +34,14 @@ public class DeviceConfigController {
     }
 
     @Operation(summary = "기기 설정 저장/수정")
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<DeviceConfigResponseDto> saveOrUpdate(@Valid @RequestBody DeviceConfigRequestDto request) {
         return ResponseEntity.ok(DeviceConfigResponseDto.from(deviceConfigService.saveOrUpdateDeviceConfig(request)));
     }
 
     @Operation(summary = "기기 설정 삭제")
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{deviceId}")
     public ResponseEntity<Void> deleteConfig(@PathVariable String deviceId) {
         deviceConfigService.deleteDeviceConfig(deviceId);
@@ -46,6 +49,7 @@ public class DeviceConfigController {
     }
 
     @Operation(summary = "API 키 재발급", description = "기기의 API 키를 새 UUID로 교체합니다. 기존 키는 즉시 무효화됩니다.")
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/{deviceId}/regenerate-key")
     public ResponseEntity<DeviceConfigResponseDto> regenerateApiKey(@PathVariable String deviceId) {
         return ResponseEntity.ok(deviceConfigService.regenerateApiKey(deviceId));

--- a/src/main/java/com/smartfarm/server/controller/DeviceControlController.java
+++ b/src/main/java/com/smartfarm/server/controller/DeviceControlController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public class DeviceControlController {
     @Operation(summary = "수동 제어 명령 발송",
             description = "대시보드에서 쿨링팬 또는 히터를 수동으로 켜거나 끄는 명령을 발송합니다. "
                     + "명령 종류: COOLING_FAN_ON / COOLING_FAN_OFF / HEATER_ON / HEATER_OFF")
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/command")
     public ResponseEntity<DeviceControlCommandResponseDto> sendCommand(
             @RequestBody DeviceControlCommandRequestDto request) {

--- a/src/main/java/com/smartfarm/server/service/DataBatchService.java
+++ b/src/main/java/com/smartfarm/server/service/DataBatchService.java
@@ -1,7 +1,9 @@
 package com.smartfarm.server.service;
 
+import com.smartfarm.server.dto.SensorStatisticsDto;
 import com.smartfarm.server.entity.SensorData;
 import com.smartfarm.server.entity.SensorHistory;
+import com.smartfarm.server.repository.DeviceConfigRepository;
 import com.smartfarm.server.repository.SensorHistoryRepository;
 import com.smartfarm.server.repository.SensorRedisRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +27,8 @@ public class DataBatchService {
 
     private final SensorRedisRepository redisRepository;
     private final SensorHistoryRepository mysqlRepository;
+    private final DeviceConfigRepository deviceConfigRepository;
+    private final DiscordNotificationService discordNotificationService;
 
     /**
      * @Scheduled를 사용한 주기적 작업
@@ -94,6 +99,50 @@ public class DataBatchService {
         } catch (Exception e) {
             log.error("[BATCH TASK] 데이터 집계/이관 중 오류 발생: {}", e.getMessage(), e);
         }
+    }
+
+    /**
+     * 매일 자정에 전날 통계를 Discord로 발송합니다.
+     * cron 표현식은 application.yaml의 smartfarm.batch.report-cron으로 설정합니다.
+     */
+    @Scheduled(cron = "${smartfarm.batch.report-cron}")
+    public void sendDailyReport() {
+        LocalDate yesterday    = LocalDate.now().minusDays(1);
+        LocalDateTime dayStart = yesterday.atStartOfDay();
+        LocalDateTime dayEnd   = yesterday.atTime(23, 59, 59, 999_999_999);
+
+        List<String> deviceIds = deviceConfigRepository.findAllDeviceIds();
+
+        if (deviceIds.isEmpty()) {
+            log.info("[DAILY REPORT] 등록된 기기가 없어 리포트를 생략합니다.");
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("📊 **[스마트팜 일간 리포트] %s**\n", yesterday));
+
+        for (String deviceId : deviceIds) {
+            SensorStatisticsDto stats = mysqlRepository.getSensorStatistics(deviceId, dayStart, dayEnd);
+
+            if (stats == null || stats.getAvgTemperature() == 0.0) {
+                sb.append(String.format("\n🖥️ **%s** — 데이터 없음\n", deviceId));
+                continue;
+            }
+
+            sb.append(String.format(
+                    "\n🖥️ **%s**\n" +
+                    "  🌡️ 온도  최고: %.1f°C  최저: %.1f°C  평균: %.1f°C\n" +
+                    "  💧 평균 메모리: %.1f%%\n",
+                    deviceId,
+                    stats.getMaxTemperature(),
+                    stats.getMinTemperature(),
+                    stats.getAvgTemperature(),
+                    stats.getAvgHumidity()
+            ));
+        }
+
+        discordNotificationService.sendMessage(sb.toString());
+        log.info("[DAILY REPORT] {} 일간 리포트 발송 완료 (기기 {}대)", yesterday, deviceIds.size());
     }
 
     /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,8 @@ smartfarm:
   batch:
     # 1분(60000ms) 단위 스케줄링 간격
     interval-ms: 60000
+    # 일간 리포트 발송 시각 (cron). 기본: 매일 자정
+    report-cron: "0 0 0 * * *"
 
   notification:
     # 디스코드 웹훅 URL 설정 (실무에서는 이 부분을 application-prod.yaml로 빼고 환경변수 처리하는 것이 안전합니다)


### PR DESCRIPTION
## Summary
- 매일 자정 전날 기기별 통계를 Discord로 자동 발송 (배치 Job)
- `@EnableMethodSecurity` + `@PreAuthorize`로 API 레벨 ADMIN/USER 권한 분리
- 초기 일반 사용자 계정 자동 생성 (user / user1234)

## Test plan
- [ ] 서버 시작 후 `user` 계정으로 로그인 → 대시보드 조회 가능 확인
- [ ] `user` 계정으로 기기 설정 저장/삭제 시도 → 403 Forbidden 확인
- [ ] `user` 계정으로 수동 제어 명령 발송 시도 → 403 Forbidden 확인
- [ ] `admin` 계정은 모든 기능 정상 동작 확인
- [ ] `report-cron`을 테스트용 cron(매분)으로 변경 후 Discord 리포트 수신 확인