### PR TITLE
refactor: 코드 리뷰 이슈 9건 수정

### DIFF
--- a/src/main/java/com/smartfarm/server/config/AdminUserInitializer.java
+++ b/src/main/java/com/smartfarm/server/config/AdminUserInitializer.java
@@ -26,7 +26,7 @@ public class AdminUserInitializer implements ApplicationRunner {
                     .role("ROLE_ADMIN")
                     .build();
             userRepository.save(admin);
-            log.info(">>> 초기 관리자 계정 생성 완료 (admin / admin1234)");
+            log.info(">>> 초기 관리자 계정 생성 완료 (username: admin)");
         }
 
         if (userRepository.findByUsername("user").isEmpty()) {
@@ -36,7 +36,7 @@ public class AdminUserInitializer implements ApplicationRunner {
                     .role("ROLE_USER")
                     .build();
             userRepository.save(user);
-            log.info(">>> 초기 일반 사용자 계정 생성 완료 (user / user1234) — 조회 전용");
+            log.info(">>> 초기 일반 사용자 계정 생성 완료 (username: user) — 조회 전용");
         }
     }
 }

--- a/src/main/java/com/smartfarm/server/config/AppConfig.java
+++ b/src/main/java/com/smartfarm/server/config/AppConfig.java
@@ -1,0 +1,22 @@
+package com.smartfarm.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 애플리케이션 공통 Bean 설정.
+ */
+@Configuration
+public class AppConfig {
+
+    /**
+     * 외부 HTTP 호출에 사용할 RestTemplate.
+     * 필드에서 직접 new RestTemplate() 하면 연결 풀이 없어 매 요청마다 소켓이 새로 생성됩니다.
+     * Bean으로 등록하면 스프링 컨텍스트에서 싱글톤으로 관리되어 재사용됩니다.
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/smartfarm/server/config/DeviceApiKeyAuthFilter.java
+++ b/src/main/java/com/smartfarm/server/config/DeviceApiKeyAuthFilter.java
@@ -71,7 +71,19 @@ public class DeviceApiKeyAuthFilter extends OncePerRequestFilter {
         }
 
         // API 키 유효성 검증
-        if (!deviceConfigService.validateApiKey(deviceId, apiKey)) {
+        boolean valid;
+        try {
+            valid = deviceConfigService.validateApiKey(deviceId, apiKey);
+        } catch (Exception ex) {
+            log.error(">>> [API Key Auth] 인증 처리 중 오류 — deviceId={}, path={}, error={}", deviceId, path, ex.getMessage(), ex);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("{\"status\":500,\"message\":\"인증 처리 중 서버 오류가 발생했습니다.\"}");
+            return;
+        }
+
+        if (!valid) {
             log.warn(">>> [API Key Auth] 인증 실패 — deviceId={}, path={}", deviceId, path);
             sendUnauthorized(response, ErrorCode.INVALID_API_KEY.getMessage());
             return;

--- a/src/main/java/com/smartfarm/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/smartfarm/server/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.smartfarm.server.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -41,11 +40,10 @@ public class GlobalExceptionHandler {
         log.error("MethodArgumentNotValidException: {}", e.getMessage());
         
         // 발생한 에러들을 Map(필드명 : 에러 메시지) 형태로 정리
+        // getFieldErrors()를 사용하면 FieldError 타입이 보장되어 ClassCastException 위험이 없습니다.
         Map<String, String> errors = new HashMap<>();
-        e.getBindingResult().getAllErrors().forEach((error) -> {
-            String fieldName = ((FieldError) error).getField();
-            String errorMessage = error.getDefaultMessage();
-            errors.put(fieldName, errorMessage);
+        e.getBindingResult().getFieldErrors().forEach((fieldError) -> {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
         });
         
         ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, errors);

--- a/src/main/java/com/smartfarm/server/repository/SensorHistoryRepositoryCustom.java
+++ b/src/main/java/com/smartfarm/server/repository/SensorHistoryRepositoryCustom.java
@@ -5,6 +5,7 @@ import com.smartfarm.server.dto.SensorStatisticsDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Querydsl을 사용한 커스텀 쿼리 메서드들을 정의하는 인터페이스입니다.
@@ -13,6 +14,9 @@ public interface SensorHistoryRepositoryCustom {
 
     // 특정 기기의 특정 기간 동안의 통계(최고, 최저, 평균 온도 및 습도)를 조회합니다.
     SensorStatisticsDto getSensorStatistics(String deviceId, LocalDateTime start, LocalDateTime end);
+
+    // 여러 기기의 특정 기간 동안의 통계를 한 번의 쿼리로 조회합니다. (N+1 방지)
+    Map<String, SensorStatisticsDto> getAllDevicesStatistics(List<String> deviceIds, LocalDateTime start, LocalDateTime end);
 
     // 특정 기기의 특정 기간을 일별로 집계한 통계 목록을 조회합니다.
     List<DailyStatisticsDto> getDailyStatistics(String deviceId, LocalDateTime start, LocalDateTime end);

--- a/src/main/java/com/smartfarm/server/repository/SensorHistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/smartfarm/server/repository/SensorHistoryRepositoryCustomImpl.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 // Querydsl 자동 생성 클래스인 QSensorHistory를 import 합니다.
 // (import 에러가 난다면, 우측 Gradle 탭 -> Tasks -> build -> build 를 더블클릭하여 Q클래스를 생성해주세요!)
@@ -44,6 +46,30 @@ public class SensorHistoryRepositoryCustomImpl implements SensorHistoryRepositor
                 )
                 .groupBy(sensorHistory.deviceId) // 디바이스별로 묶어서 통계를 냅니다.
                 .fetchOne(); // 결과가 1건(또는 null)이므로 fetchOne()을 사용합니다.
+    }
+
+    @Override
+    public Map<String, SensorStatisticsDto> getAllDevicesStatistics(List<String> deviceIds, LocalDateTime start, LocalDateTime end) {
+        // 단일 쿼리로 모든 기기의 통계를 한 번에 조회합니다. (N+1 방지)
+        List<SensorStatisticsDto> results = queryFactory
+                .select(Projections.constructor(SensorStatisticsDto.class,
+                        sensorHistory.deviceId,
+                        sensorHistory.temperature.max(),
+                        sensorHistory.temperature.min(),
+                        sensorHistory.temperature.avg(),
+                        sensorHistory.humidity.avg()
+                ))
+                .from(sensorHistory)
+                .where(
+                        sensorHistory.deviceId.in(deviceIds),
+                        sensorHistory.timestamp.between(start, end),
+                        sensorHistory.deletedAt.isNull()
+                )
+                .groupBy(sensorHistory.deviceId)
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(SensorStatisticsDto::getDeviceId, dto -> dto));
     }
 
     @Override

--- a/src/main/java/com/smartfarm/server/service/CommandTimeoutScheduler.java
+++ b/src/main/java/com/smartfarm/server/service/CommandTimeoutScheduler.java
@@ -27,7 +27,7 @@ public class CommandTimeoutScheduler {
     private final DeviceControlCommandRepository commandRepository;
 
     @Transactional
-    @Scheduled(fixedDelay = 5 * 60 * 1000L) // 5분마다
+    @Scheduled(fixedRate = 5 * 60 * 1000L) // 5분마다 (fixedRate: 이전 실행 완료 여부와 무관하게 고정 주기 보장)
     public void cancelTimedOutCommands() {
         LocalDateTime cutoff = LocalDateTime.now().minusMinutes(TIMEOUT_MINUTES);
         int cancelled = commandRepository.cancelTimedOutPendingCommands(cutoff);

--- a/src/main/java/com/smartfarm/server/service/DashboardService.java
+++ b/src/main/java/com/smartfarm/server/service/DashboardService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -80,17 +81,28 @@ public class DashboardService {
 
     /**
      * 등록된 모든 기기의 오늘 통계를 비교하여 반환합니다.
+     * 단일 쿼리로 모든 기기 통계를 조회하여 N+1 문제를 방지합니다.
      */
     public List<DeviceComparisonDto> getAllDevicesComparison() {
         LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
         LocalDateTime endOfDay   = LocalDate.now().atTime(23, 59, 59, 999999999);
 
         List<DeviceConfig> configs = deviceConfigRepository.findAll();
+        if (configs.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> deviceIds = configs.stream()
+                .map(DeviceConfig::getDeviceId)
+                .collect(Collectors.toList());
+
+        // 단일 쿼리로 모든 기기 통계 한 번에 조회 (N+1 방지)
+        Map<String, SensorStatisticsDto> statsMap =
+                historyRepository.getAllDevicesStatistics(deviceIds, startOfDay, endOfDay);
 
         return configs.stream()
                 .map(config -> {
-                    SensorStatisticsDto stats = historyRepository.getSensorStatistics(
-                            config.getDeviceId(), startOfDay, endOfDay);
+                    SensorStatisticsDto stats = statsMap.get(config.getDeviceId());
                     return DeviceComparisonDto.builder()
                             .deviceId(config.getDeviceId())
                             .maxTemperature(stats != null ? stats.getMaxTemperature() : null)

--- a/src/main/java/com/smartfarm/server/service/DataBatchService.java
+++ b/src/main/java/com/smartfarm/server/service/DataBatchService.java
@@ -124,7 +124,7 @@ public class DataBatchService {
         for (String deviceId : deviceIds) {
             SensorStatisticsDto stats = mysqlRepository.getSensorStatistics(deviceId, dayStart, dayEnd);
 
-            if (stats == null || stats.getAvgTemperature() == 0.0) {
+            if (stats == null) {
                 sb.append(String.format("\n🖥️ **%s** — 데이터 없음\n", deviceId));
                 continue;
             }

--- a/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
+++ b/src/main/java/com/smartfarm/server/service/DeviceConfigService.java
@@ -95,13 +95,15 @@ public class DeviceConfigService {
     }
 
     /**
-     * PC 클라이언트 API 키 유효성 검증
+     * PC 클라이언트 API 키 유효성 검증.
      * X-Device-Id, X-Api-Key 헤더 값을 검증합니다.
+     *
+     * <p>캐시된 {@link #getDeviceConfig(String)}를 사용하여 매 요청마다 DB를 조회하지 않습니다.</p>
      */
     public boolean validateApiKey(String deviceId, String apiKey) {
-        return deviceConfigRepository.findByDeviceId(deviceId)
-                .map(config -> config.getApiKey() != null && config.getApiKey().equals(apiKey))
-                .orElse(false);
+        DeviceConfig config = getDeviceConfig(deviceId);
+        // apiKey가 null이면 미등록 기기(기본 설정 반환)이거나 키 발급 전 상태이므로 인증 거부
+        return config.getApiKey() != null && config.getApiKey().equals(apiKey);
     }
 
     /**

--- a/src/main/java/com/smartfarm/server/service/DiscordNotificationService.java
+++ b/src/main/java/com/smartfarm/server/service/DiscordNotificationService.java
@@ -34,8 +34,8 @@ public class DiscordNotificationService {
 
     private final StringRedisTemplate redisTemplate;
 
-    // HTTP 요청을 보내기 위한 RestTemplate 객체 (간단한 동기식 요청에 적합)
-    private final RestTemplate restTemplate = new RestTemplate();
+    // AppConfig에서 Bean으로 등록된 RestTemplate 주입 (싱글톤 재사용, 연결 풀 관리)
+    private final RestTemplate restTemplate;
 
     /**
      * 쿨다운을 적용하여 알림을 발송합니다.

--- a/src/main/java/com/smartfarm/server/service/SensorService.java
+++ b/src/main/java/com/smartfarm/server/service/SensorService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -37,6 +38,7 @@ public class SensorService {
     @Value("${smartfarm.sensor.validation.humidity-max}")
     private double humidityMax;
 
+    @Transactional
     public SensorResponseDto processSensorData(SensorRequestDto requestDto) {
         log.info("수신된 센서 데이터 확인: {}", requestDto);
 


### PR DESCRIPTION
## Summary

### 🔴 심각 (3건)
- **N+1 쿼리 제거**: `DashboardService.getAllDevicesComparison()`에서 기기 수만큼 발생하던 개별 쿼리를 `QueryDSL IN절` 단일 쿼리로 교체. `SensorHistoryRepositoryCustom`에 `getAllDevicesStatistics(deviceIds, start, end)` 메서드 추가
- **RestTemplate Bean화**: `DiscordNotificationService`에서 `new RestTemplate()` 필드 직접 생성 → `AppConfig`에 `@Bean`으로 등록하여 싱글톤 재사용
- **sendDailyReport null check**: `stats.getAvgTemperature() == 0.0` 조건 제거 (0.0도 평균이 유효한 값일 수 있음, `stats == null`만으로 충분)

### 🟡 경고 (4건)
- **DeviceApiKeyAuthFilter 예외 처리**: `validateApiKey()` 호출 중 예외 발생 시 NPE/500 대신 명시적 `500 JSON` 응답 반환
- **validateApiKey 캐시 활용**: DB 직접 조회(`repository.findByDeviceId`) → 캐시된 `getDeviceConfig()` 사용 (PC 클라이언트 3초 주기 요청 시 매번 DB 조회 방지)
- **SensorService @Transactional 누락**: `processSensorData()`에 `@Transactional` 추가
- **GlobalExceptionHandler FieldError 캐스팅**: `getAllErrors() + (FieldError) 캐스팅` → `getFieldErrors()` 사용 (ClassCastException 위험 제거)

### 🔵 개선 (2건)
- **AdminUserInitializer 로그 정화**: 초기 비밀번호(`admin1234`, `user1234`) 로그 출력 제거
- **CommandTimeoutScheduler fixedRate**: `fixedDelay` → `fixedRate`로 변경 (이전 실행 완료 여부와 무관하게 고정 5분 주기 보장)

## Test plan
- [ ] `./gradlew build` 빌드 성공 확인
- [ ] 대시보드 기기 비교 탭 정상 로드 (N+1 → 단일 쿼리, 로그에 DB 쿼리 1회만 출력)
- [ ] Discord 알림 발송 정상 동작
- [ ] API 키 없이 `/api/sensor/data` 호출 시 401 반환
- [ ] `POST /api/device-config` 요청 시 validation 에러 메시지 필드별로 정상 반환