### PR TITLE
refactor: Service 레이어를 Thin Service 패턴으로 리팩토링

### DIFF
--- a/src/main/java/com/smartfarm/server/sensor/service/SensorAlert.java
+++ b/src/main/java/com/smartfarm/server/sensor/service/SensorAlert.java
@@ -1,0 +1,48 @@
+package com.smartfarm.server.sensor.service;
+
+import com.smartfarm.server.sensor.entity.SensorData;
+import com.smartfarm.server.device.dto.DeviceConfigView;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 센서 데이터 기반 경고 상태를 나타내는 도메인 객체
+ * - 임계값 초과 여부
+ * - 제어 명령 (쿨링팬, 히터)
+ * - 경고 메시지
+ */
+@Getter
+@Builder
+public class SensorAlert {
+
+    private final String deviceId;
+    private final SensorData sensorData;
+    private final DeviceConfigView config;
+
+    private final boolean coolingFanOn;
+    private final boolean heaterOn;
+
+    private final String coolingMessage;
+    private final String heatingMessage;
+
+    /**
+     * 경고 발생 여부 판단
+     */
+    public boolean hasAlert() {
+        return coolingFanOn || heaterOn;
+    }
+
+    /**
+     * 쿨링팬 경고 여부
+     */
+    public boolean hasCoolingAlert() {
+        return coolingFanOn;
+    }
+
+    /**
+     * 히터 경고 여부
+     */
+    public boolean hasHeatingAlert() {
+        return heaterOn;
+    }
+}

--- a/src/main/java/com/smartfarm/server/sensor/service/SensorAlertEventHandler.java
+++ b/src/main/java/com/smartfarm/server/sensor/service/SensorAlertEventHandler.java
@@ -1,0 +1,82 @@
+package com.smartfarm.server.sensor.service;
+
+import com.smartfarm.server.dashboard.dto.SsePayloadDto;
+import com.smartfarm.server.control.service.DeviceControlService;
+import com.smartfarm.server.notification.service.DiscordNotificationService;
+import com.smartfarm.server.dashboard.service.SseEmitterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 센서 경고 이벤트 처리 (로깅, 알림, 실시간 푸시)
+ * - 경고 발생 시 자동 제어 명령 발송
+ * - Discord 알림 발송
+ * - SSE를 통한 실시간 클라이언트 푸시
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SensorAlertEventHandler {
+
+    private final DeviceControlService deviceControlService;
+    private final DiscordNotificationService discordNotificationService;
+    private final SseEmitterService sseEmitterService;
+
+    /**
+     * 센서 경고 이벤트 처리
+     * @param alert 센서 경고 상태
+     */
+    public void handle(SensorAlert alert) {
+        if (!alert.hasAlert()) {
+            log.debug("경고 없음: {}", alert.getDeviceId());
+            return;
+        }
+
+        String deviceId = alert.getDeviceId();
+
+        // 1. 쿨링팬 경고 처리
+        if (alert.hasCoolingAlert()) {
+            handleCoolingAlert(deviceId, alert.getCoolingMessage());
+        }
+
+        // 2. 히터 경고 처리
+        if (alert.hasHeatingAlert()) {
+            handleHeatingAlert(deviceId, alert.getHeatingMessage());
+        }
+
+        // 3. 실시간 SSE 푸시
+        sendSsePush(alert);
+    }
+
+    private void handleCoolingAlert(String deviceId, String message) {
+        // 자동 제어 명령 발송
+        deviceControlService.sendAutoCommand(deviceId, "COOLING_FAN_ON");
+
+        // Discord 알림
+        String discordMsg = String.format("🚨 **[스마트팜 경고] %s 쿨링팬 가동!**\n%s", deviceId, message);
+        discordNotificationService.sendAlertIfNotCoolingDown(deviceId, "TEMP", discordMsg);
+    }
+
+    private void handleHeatingAlert(String deviceId, String message) {
+        // 자동 제어 명령 발송
+        deviceControlService.sendAutoCommand(deviceId, "HEATER_ON");
+
+        // Discord 알림
+        String discordMsg = String.format("💧 **[스마트팜 경고] %s 히터 가동!**\n%s", deviceId, message);
+        discordNotificationService.sendAlertIfNotCoolingDown(deviceId, "HUMIDITY", discordMsg);
+    }
+
+    private void sendSsePush(SensorAlert alert) {
+        SsePayloadDto payload = SsePayloadDto.builder()
+                .deviceId(alert.getDeviceId())
+                .temperature(alert.getSensorData().getTemperature())
+                .memUsage(alert.getSensorData().getMemUsage())
+                .timestamp(alert.getSensorData().getTimestamp())
+                .coolingFanOn(alert.isCoolingFanOn())
+                .heaterOn(alert.isHeaterOn())
+                .build();
+
+        sseEmitterService.sendToDevice(alert.getDeviceId(), payload);
+    }
+}

--- a/src/main/java/com/smartfarm/server/sensor/service/SensorControlStrategy.java
+++ b/src/main/java/com/smartfarm/server/sensor/service/SensorControlStrategy.java
@@ -1,0 +1,52 @@
+package com.smartfarm.server.sensor.service;
+
+import com.smartfarm.server.sensor.entity.SensorData;
+import com.smartfarm.server.device.dto.DeviceConfigView;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 센서 데이터와 기기 설정을 기반으로 제어 판단하는 비즈니스 로직
+ * - 온도/메모리 임계값 비교
+ * - 쿨링팬/히터 제어 결정
+ */
+@Slf4j
+@Component
+public class SensorControlStrategy {
+
+    /**
+     * 센서 데이터와 기기 설정을 비교하여 제어 여부 결정
+     * @param sensorData 수신된 센서 데이터
+     * @param config 기기 설정 (임계값)
+     * @return 제어 상태 정보
+     */
+    public SensorAlert determineControl(SensorData sensorData, DeviceConfigView config) {
+        boolean needCooling = sensorData.getTemperature() >= config.temperatureThresholdHigh();
+        boolean needHeater = sensorData.getMemUsage() >= config.memUsageThresholdHigh();
+
+        String coolingMessage = null;
+        String heatingMessage = null;
+
+        if (needCooling) {
+            coolingMessage = String.format("현재 온도: %.1f도, 설정 기준치: %.1f도",
+                    sensorData.getTemperature(), config.temperatureThresholdHigh());
+            log.warn("🚨 {} 온도 경고! 쿨링팬 가동 명령 발행! ({})", sensorData.getDeviceId(), coolingMessage);
+        }
+
+        if (needHeater) {
+            heatingMessage = String.format("현재 메모리 사용률: %.1f%%, 설정 기준치: %.1f%%",
+                    sensorData.getMemUsage(), config.memUsageThresholdHigh());
+            log.warn("🚨 {} 메모리 사용률 경고! 히터 가동 명령 발행! ({})", sensorData.getDeviceId(), heatingMessage);
+        }
+
+        return SensorAlert.builder()
+                .deviceId(sensorData.getDeviceId())
+                .sensorData(sensorData)
+                .config(config)
+                .coolingFanOn(needCooling)
+                .heaterOn(needHeater)
+                .coolingMessage(coolingMessage)
+                .heatingMessage(heatingMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/smartfarm/server/sensor/service/SensorService.java
+++ b/src/main/java/com/smartfarm/server/sensor/service/SensorService.java
@@ -3,21 +3,18 @@ package com.smartfarm.server.sensor.service;
 import com.smartfarm.server.device.dto.DeviceConfigView;
 import com.smartfarm.server.sensor.dto.SensorRequestDto;
 import com.smartfarm.server.sensor.dto.SensorResponseDto;
-import com.smartfarm.server.dashboard.dto.SsePayloadDto;
 import com.smartfarm.server.sensor.entity.SensorData;
-import com.smartfarm.server.common.exception.CustomException;
-import com.smartfarm.server.common.exception.ErrorCode;
 import com.smartfarm.server.sensor.repository.SensorRedisRepository;
 import com.smartfarm.server.device.service.DeviceConfigService;
-import com.smartfarm.server.dashboard.service.SseEmitterService;
-import com.smartfarm.server.control.service.DeviceControlService;
-import com.smartfarm.server.notification.service.DiscordNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 센서 데이터 처리 서비스 (Thin Service Pattern)
+ * - 유효성 검사, 비즈니스 로직, 이벤트 처리를 전문 컴포넌트에 위임
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -25,29 +22,16 @@ public class SensorService {
 
     private final SensorRedisRepository sensorRepository;
     private final DeviceConfigService deviceConfigService;
-    private final DiscordNotificationService discordNotificationService;
-    private final SseEmitterService sseEmitterService;
-    private final DeviceControlService deviceControlService;
-
-    // application.yaml에서 유효성 검사 기준값을 가져옵니다.
-    @Value("${smartfarm.sensor.validation.temp-min}")
-    private double tempMin;
-
-    @Value("${smartfarm.sensor.validation.temp-max}")
-    private double tempMax;
-
-    @Value("${smartfarm.sensor.validation.mem-usage-min}")
-    private double memUsageMin;
-
-    @Value("${smartfarm.sensor.validation.mem-usage-max}")
-    private double memUsageMax;
+    private final SensorValidator sensorValidator;
+    private final SensorControlStrategy sensorControlStrategy;
+    private final SensorAlertEventHandler sensorAlertEventHandler;
 
     @Transactional
     public SensorResponseDto processSensorData(SensorRequestDto requestDto) {
         log.info("수신된 센서 데이터 확인: {}", requestDto);
 
-        // 1. 데이터 유효성 검사 (yaml 설정값 기반)
-        validateSensorData(requestDto);
+        // 1. 데이터 유효성 검사 (YAML 설정값 기반)
+        sensorValidator.validate(requestDto);
 
         // 2. DTO -> Entity 변환 및 Redis 저장
         SensorData sensorData = requestDto.toEntity();
@@ -57,67 +41,18 @@ public class SensorService {
         // 3. 기기별 설정값 조회
         DeviceConfigView config = deviceConfigService.getDeviceConfig(sensorData.getDeviceId());
 
-        // 4. 비즈니스 로직 (임계값 초과 여부 판단)
-        boolean needCooling        = sensorData.getTemperature() >= config.temperatureThresholdHigh();
-        boolean needMemUsageControl = sensorData.getMemUsage()   >= config.memUsageThresholdHigh();
+        // 4. 제어 판단 (임계값 비교 및 경고 생성)
+        SensorAlert alert = sensorControlStrategy.determineControl(sensorData, config);
 
-        // 5. 경고 발생 시 자동 제어 명령 발송 + DB 이력 기록 + 디스코드 알림
-        if (needCooling) {
-            String message = String.format("현재 온도: %.1f도, 설정 기준치: %.1f도",
-                                           sensorData.getTemperature(), config.temperatureThresholdHigh());
-            log.warn("🚨 {} 온도 경고! 쿨링팬 가동 명령 발행! ({})", sensorData.getDeviceId(), message);
+        // 5. 경고 처리 (제어 명령 발송, 알림, SSE 푸시)
+        sensorAlertEventHandler.handle(alert);
 
-            deviceControlService.sendAutoCommand(sensorData.getDeviceId(), "COOLING_FAN_ON");
-
-            String discordMsg = String.format("🚨 **[스마트팜 경고] %s 쿨링팬 가동!**\n%s", sensorData.getDeviceId(), message);
-            discordNotificationService.sendAlertIfNotCoolingDown(sensorData.getDeviceId(), "TEMP", discordMsg);
-        }
-
-        if (needMemUsageControl) {
-            String message = String.format("현재 메모리 사용률: %.1f%%, 설정 기준치: %.1f%%",
-                                           sensorData.getMemUsage(), config.memUsageThresholdHigh());
-            log.warn("🚨 {} 메모리 사용률 경고! 히터 가동 명령 발행! ({})", sensorData.getDeviceId(), message);
-
-            deviceControlService.sendAutoCommand(sensorData.getDeviceId(), "HEATER_ON");
-
-            String discordMsg = String.format("💧 **[스마트팜 경고] %s 히터 가동!**\n%s", sensorData.getDeviceId(), message);
-            discordNotificationService.sendAlertIfNotCoolingDown(sensorData.getDeviceId(), "HUMIDITY", discordMsg);
-        }
-
-        // 6. SSE로 실시간 데이터 push
-        sseEmitterService.sendToDevice(sensorData.getDeviceId(), SsePayloadDto.builder()
-                .deviceId(sensorData.getDeviceId())
-                .temperature(sensorData.getTemperature())
-                .memUsage(sensorData.getMemUsage())
-                .timestamp(sensorData.getTimestamp())
-                .coolingFanOn(needCooling)
-                .heaterOn(needMemUsageControl)
-                .build());
-
-        // 7. 응답 반환
+        // 6. 응답 반환
         return SensorResponseDto.builder()
                 .status("SUCCESS")
                 .message("Data processed successfully")
-                .coolingFanOn(needCooling)
-                .heaterOn(needMemUsageControl)
+                .coolingFanOn(alert.isCoolingFanOn())
+                .heaterOn(alert.isHeaterOn())
                 .build();
     }
-
-    /**
-     * yaml 설정값을 기반으로 동적 유효성 검사를 수행합니다.
-     */
-    private void validateSensorData(SensorRequestDto requestDto) {
-        if (requestDto.getCpuTemperature() < tempMin || requestDto.getCpuTemperature() > tempMax) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
-                    String.format("온도는 %.1f도에서 %.1f도 사이여야 합니다. (입력값: %.1f)",
-                            tempMin, tempMax, requestDto.getCpuTemperature()));
-        }
-
-        if (requestDto.getMemUsage() < memUsageMin || requestDto.getMemUsage() > memUsageMax) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
-                    String.format("메모리 사용률은 %.1f%%에서 %.1f%% 사이여야 합니다. (입력값: %.1f)",
-                            memUsageMin, memUsageMax, requestDto.getMemUsage()));
-        }
-    }
-
 }

--- a/src/main/java/com/smartfarm/server/sensor/service/SensorValidator.java
+++ b/src/main/java/com/smartfarm/server/sensor/service/SensorValidator.java
@@ -1,0 +1,57 @@
+package com.smartfarm.server.sensor.service;
+
+import com.smartfarm.server.sensor.dto.SensorRequestDto;
+import com.smartfarm.server.common.exception.CustomException;
+import com.smartfarm.server.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * 센서 데이터 유효성 검사 담당
+ * - 온도, 메모리 사용률 범위 검증 (YAML 설정 기반)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SensorValidator {
+
+    @Value("${smartfarm.sensor.validation.temp-min}")
+    private double tempMin;
+
+    @Value("${smartfarm.sensor.validation.temp-max}")
+    private double tempMax;
+
+    @Value("${smartfarm.sensor.validation.mem-usage-min}")
+    private double memUsageMin;
+
+    @Value("${smartfarm.sensor.validation.mem-usage-max}")
+    private double memUsageMax;
+
+    /**
+     * 센서 요청 데이터 유효성 검사
+     * @param requestDto 센서 요청 DTO
+     * @throws CustomException 검증 실패 시
+     */
+    public void validate(SensorRequestDto requestDto) {
+        validateTemperature(requestDto.getCpuTemperature());
+        validateMemUsage(requestDto.getMemUsage());
+    }
+
+    private void validateTemperature(double temperature) {
+        if (temperature < tempMin || temperature > tempMax) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
+                    String.format("온도는 %.1f도에서 %.1f도 사이여야 합니다. (입력값: %.1f)",
+                            tempMin, tempMax, temperature));
+        }
+    }
+
+    private void validateMemUsage(double memUsage) {
+        if (memUsage < memUsageMin || memUsage > memUsageMax) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
+                    String.format("메모리 사용률은 %.1f%%에서 %.1f%% 사이여야 합니다. (입력값: %.1f)",
+                            memUsageMin, memUsageMax, memUsage));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Service 계층을 Thin Service 패턴으로 리팩토링하여 단일 책임 원칙 준수

**Before**: 123줄, 8개의 책임 (검증, 변환, 캐싱, 비즈니스 로직, 제어, 로깅, 알림, SSE)
**After**: 48줄, 순수 오케스트레이션

## Changes
- **SensorValidator**: YAML 설정 기반 유효성 검사 전담 (`@Component`)
- **SensorControlStrategy**: 임계값 비교 및 제어 판단 비즈니스 로직
- **SensorAlertEventHandler**: 제어 명령, Discord 알림, SSE 푸시 처리 전담  
- **SensorAlert**: 경고 상태를 나타내는 도메인 객체 (`@Getter @Builder`)
- **SensorService**: 컴포넌트 간 흐름 조정만 담당

## Build Status
✅ Build successful (gradle clean build -x test)

## Dependency Flow
```
SensorService
  ↓ validate
  └→ SensorValidator
  ↓ determineControl
  └→ SensorControlStrategy
  ↓ handle
  └→ SensorAlertEventHandler
```