### PR TITLE
Add security regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > 단순한 데이터 저장을 넘어, Redis와 MySQL의 이중 저장소 전략으로 고속 수집과 영구 보관을 동시에 달성했습니다.
 >
-> Server-Sent Events(SSE) 기반 실시간 푸시, 1분 단위 배치 집계, 임계값 초과 시 쿨링팬·히터·가습기 자동 제어, Discord 알림까지 실제 운영 환경을 고려한 아키텍처를 구축했습니다.
+> Server-Sent Events(SSE) 기반 실시간 푸시, 1분 단위 배치 이관, 임계값 초과 시 쿨링팬·히터·가습기 자동 제어, Discord 알림까지 실제 운영 환경을 고려한 아키텍처를 구축했습니다.
 
 
 🔗 **실제 서비스 접속해 보기:** [https://smartfarm.rkqkdrnportfolio.shop/](https://smartfarm.rkqkdrnportfolio.shop/)
@@ -24,6 +24,7 @@
 - [주요 기술적 의사결정 및 트러블슈팅](#-주요-기술적-의사결정-및-트러블-슈팅)
 - [API 엔드포인트](#-api-엔드포인트)
 - [실행 방법](#-실행-방법)
+- [테스트](#-테스트)
 - [센서 에이전트 (Python)](#-센서-에이전트-python)
 - [예외 처리](#-예외-처리)
 
@@ -32,7 +33,7 @@
 ## 🛠️ Tech Stack & Architecture
 
 ### Tech Stack
-* **Backend:** Java 21, Spring Boot 3.5, Spring Data JPA, Querydsl, Spring Security 6
+* **Backend:** Java 21, Spring Boot 3.5.11, Spring Data JPA, Querydsl, Spring Security 6
 * **Database & Cache:** MySQL 8, Redis, Flyway (DB 마이그레이션)
 * **Realtime:** Server-Sent Events (SSE) — 대시보드 실시간 푸시 + PC 클라이언트 명령 스트림
 * **Sensor Agent:** Python 3 (가상 온도·습도 데이터 생성 및 전송, systemd 서비스 운용)
@@ -48,7 +49,7 @@
 
 
 * **Redis:** 3초마다 쏟아지는 센서 데이터를 메모리에 임시 버퍼링하여 DB 쓰기 부하 차단
-* **MySQL:** 1분 평균값만 영구 저장하여 스토리지 효율 극대화
+* **MySQL:** Redis에 남은 기기별 최신 스냅샷을 1분마다 영구 저장하여 쓰기 부하 절감
 * **Spring Cache (Redis 백엔드):** 기기별 임계값 설정을 캐시하여 매 요청마다 발생하는 DB 조회 제거
 * **SSE (이중 채널):** 브라우저 대시보드용 실시간 센서 스트림 + PC 클라이언트용 제어 명령 스트림을 분리하여 운용
 * **자동 제어:** 온도 상한 초과 시 쿨링팬 ON, 중간값 이하 도달 시 자동 OFF / 온도 하한 미달 시 히터 ON, 중간값 이상 도달 시 자동 OFF / 습도 하한 이하 시 가습기 ON (건조), 중간값 이상 도달 시 자동 OFF
@@ -59,12 +60,12 @@
 ## 💡 주요 기술적 의사결정 및 트러블 슈팅
 
 ### 1. ⚡ Redis + MySQL 이중 저장소 전략 (Write-Buffer + Batch Flush)
-> **의사결정:** 3초마다 발생하는 고빈도 쓰기 요청을 MySQL이 직접 받지 않도록 Redis를 중간 버퍼로 사용하고, 1분 단위 배치로 집계 후 저장
+> **의사결정:** 3초마다 발생하는 고빈도 쓰기 요청을 MySQL이 직접 받지 않도록 Redis를 중간 버퍼로 사용하고, 1분 단위 배치로 최신 스냅샷을 이관
 
 * **🚨 Issue:** 기기에서 3초마다 온도·습도 데이터를 전송할 경우, 기기 수가 늘어날수록 MySQL에 초당 수십 건의 INSERT가 발생해 DB 병목이 불가피
 * **💡 Resolution:**
   * **Redis 임시 버퍼:** 수신 즉시 Redis에 저장 (기기당 최신 1건만 유지, 60초 TTL)
-  * **Batch Flush:** `@Scheduled`로 1분마다 Redis 전체 데이터를 읽어 deviceId별 평균값을 계산한 뒤 MySQL에 1행만 삽입
+  * **Batch Flush:** `@Scheduled`로 1분마다 등록된 deviceId 목록을 기준으로 Redis의 기기별 최신값을 조회해 MySQL에 1행씩 삽입
   * **메모리 해제:** 배치 완료 후 Redis 데이터 즉시 삭제
 * **📈 성과:** DB INSERT 횟수를 기기당 분당 20건 → 1건으로 절감 (기기 10대 기준 약 95% 감소)
 
@@ -165,7 +166,7 @@
 
 * **🚨 Issue:** JPA 메서드 네이밍만으로 집계(max, min, avg)와 날짜 범위 필터를 조합한 동적 쿼리를 표현하기 어려움
 * **💡 Resolution:**
-  * **Querydsl Projections:** `QSensorStatisticsDto`로 집계 결과를 DTO에 직접 매핑, 엔티티 불필요 조회 제거
+  * **Querydsl Projections:** `Projections.constructor(...)`로 집계 결과를 DTO에 직접 매핑, 엔티티 불필요 조회 제거
   * **BooleanExpression:** 날짜 범위, deviceId 조건을 타입 안전하게 조합
   * **Repository-Custom-Impl 3단 구조:** JPA 인터페이스와 Querydsl 구현체를 분리하여 유지보수성 확보
 * **📈 성과:** 집계 로직 DB 위임으로 애플리케이션 메모리 부하 절감, 컴파일 타임 쿼리 검증으로 런타임 오류 사전 차단
@@ -191,6 +192,7 @@
 | GET | `/api/device-config/{deviceId}` | ✅ | 특정 기기 설정 조회 |
 | POST | `/api/device-config` | ✅ | 기기 설정 저장/수정 (임계값 포함) |
 | DELETE | `/api/device-config/{deviceId}` | ✅ | 기기 삭제 |
+| POST | `/api/device-config/{deviceId}/regenerate-key` | ✅ ADMIN | API 키 재발급 |
 
 ### 기기 제어
 | Method | URI | 인증 | 설명 |
@@ -206,8 +208,23 @@
 |--------|-----|------|------|
 | GET | `/api/dashboard/history` | ✅ | 센서 이력 페이징 조회 |
 | GET | `/api/dashboard/statistics/today` | ✅ | 오늘 통계 조회 |
-| GET | `/api/dashboard/export/csv` | ✅ | CSV 내보내기 |
-| GET | `/api/dashboard/export/excel` | ✅ | Excel 내보내기 |
+| GET | `/api/dashboard/statistics/trend` | ✅ | 일별 트렌드 통계 조회 |
+| GET | `/api/dashboard/statistics/alert-count` | ✅ | 알림 발생 횟수 조회 |
+| GET | `/api/dashboard/statistics/comparison` | ✅ | 전체 기기 비교 통계 조회 |
+
+### 데이터 내보내기
+| Method | URI | 인증 | 설명 |
+|--------|-----|------|------|
+| GET | `/api/export/csv` | ✅ ADMIN | CSV 내보내기 |
+| GET | `/api/export/excel` | ✅ ADMIN | Excel 내보내기 |
+
+### 사용자 관리
+| Method | URI | 인증 | 설명 |
+|--------|-----|------|------|
+| GET | `/api/users` | ✅ ADMIN | 전체 사용자 목록 조회 |
+| POST | `/api/users` | ✅ ADMIN | 사용자 생성 |
+| PUT | `/api/users/{id}` | ✅ ADMIN | 사용자 권한/연결 기기 수정 |
+| DELETE | `/api/users/{id}` | ✅ ADMIN | 사용자 삭제 |
 
 ### 실시간 (SSE)
 | Method | URI | 인증 | 설명 |
@@ -232,7 +249,9 @@
 | `DB_HOST` | (운영) MySQL 호스트 |
 | `DB_USERNAME` | (운영) MySQL 계정 |
 | `DB_PASSWORD` | (운영) MySQL 비밀번호 |
+| `MYSQL_PASSWORD` | (로컬) MySQL root 비밀번호 |
 | `REDIS_HOST` | (운영) Redis 호스트 |
+| `REDIS_PORT` | (운영) Redis 포트 (기본값 6379) |
 
 ### 실행
 ```bash
@@ -251,6 +270,23 @@
 
 <br>
 
+## ✅ 테스트
+
+```bash
+./gradlew test
+```
+
+테스트 프로필은 H2 인메모리 DB와 메모리 기반 Spring Cache를 사용합니다. 따라서 단위/통합 테스트 실행 시 로컬 Redis가 없어도 됩니다.
+
+현재 주요 검증 범위는 다음과 같습니다.
+
+* **API 키 인증:** `X-Device-Id`로 인증된 기기와 요청 본문·쿼리·ACK 대상 기기가 다르면 거부
+* **대시보드 SSE 권한:** 일반 사용자는 연결된 기기만 실시간 구독 가능
+* **제어 상태 복원:** 쿨링팬·히터·가습기별 최신 ACK 명령을 기준으로 ON/OFF 상태 계산
+* **감사 로그:** API 키 생성·갱신, 인증 실패, 권한 거부 등 보안 이벤트 기록
+
+<br>
+
 ## 🐍 센서 에이전트 (Python)
 
 `src/scripts/sensor_agent.py` — 가상 온도·습도 데이터를 생성하여 3초마다 서버에 전송하고, SSE로 제어 명령을 수신·실행하는 PC 클라이언트입니다.
@@ -259,14 +295,14 @@
 * **일교차 패턴:** 06:00 최저 → 14:30 최고 → 다음 06:00 최저 (sin/cos 곡선)
 * **기기 피드백:** 서버에서 제어 명령 수신 시 센서 값에 즉시 반영
   * 쿨링팬 ON → 매 사이클마다 온도 −0.2°C 보정 (최저 18°C 하한)
-  * 히터 ON → 매 사이클마다 온도 +0.2°C 보정 (최고 40°C 상한)
+  * 히터 ON → 매 사이클마다 온도 +0.2°C 보정 (최고 28°C 상한)
   * 가습기 ON → 매 사이클마다 습도 +0.4% 보정 (최고 90% 상한)
   * 각 기기 OFF → 보정 없이 일교차 패턴으로 자연 복귀
 * **스레드 안전성:** SSE 수신 스레드와 센서 전송 스레드 간 `threading.Lock`으로 기기 상태 공유
 
 ### 사전 요구사항
 ```bash
-pip install requests sseclient-py python-dotenv
+pip install -r src/scripts/requirements.txt
 ```
 
 ### 환경변수 (`.env`)
@@ -277,7 +313,7 @@ API_KEY=              # 최초 실행 시 자동 발급 후 저장
 
 ### 실행
 ```bash
-python sensor_agent.py
+python src/scripts/sensor_agent.py
 ```
 
 최초 실행 시 서버에 기기를 자동 등록하고 API 키를 `.env`에 저장합니다.
@@ -302,9 +338,15 @@ journalctl -u smartfarm-sensor-agent -f
 |------|------|------|
 | E001 | 400 | 입력값 오류 |
 | E002 | 400 | 기기 없음 |
+| E003 | 400 | 존재하지 않는 명령 |
+| E004 | 400 | 유효하지 않은 명령 종류 |
+| E005 | 409 | 이미 등록된 기기 |
+| E006 | 429 | 요청 횟수 제한 초과 |
+| A001 | 401 | 유효하지 않은 API 키 |
+| A002 | 403 | 기기 접근 권한 없음 |
 | S001 | 500 | 서버 내부 오류 |
 | S002 | 500 | 데이터베이스 오류 |
 
 ---
 
-최근 업데이트 2026.04.08 — v1.1.0
+최근 업데이트 2026.04.30 — v1.1.0

--- a/src/main/java/com/smartfarm/server/control/controller/DeviceControlController.java
+++ b/src/main/java/com/smartfarm/server/control/controller/DeviceControlController.java
@@ -4,9 +4,11 @@ import com.smartfarm.server.control.dto.CommandAckRequestDto;
 import com.smartfarm.server.control.dto.DeviceControlCommandRequestDto;
 import com.smartfarm.server.control.dto.DeviceControlCommandResponseDto;
 import com.smartfarm.server.control.service.DeviceControlService;
+import com.smartfarm.server.device.filter.DeviceApiKeyAuthFilter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -44,7 +46,9 @@ public class DeviceControlController {
     @GetMapping("/pending")
     public ResponseEntity<List<DeviceControlCommandResponseDto>> getPendingCommands(
             @Parameter(description = "기기 ID", example = "WINDOWS_PC_01")
-            @RequestParam String deviceId) {
+            @RequestParam String deviceId,
+            HttpServletRequest request) {
+        DeviceApiKeyAuthFilter.assertAuthenticatedDevice(request, deviceId);
         return ResponseEntity.ok(deviceControlService.getPendingCommands(deviceId));
     }
 
@@ -52,8 +56,11 @@ public class DeviceControlController {
             description = "PC 클라이언트가 명령을 수신하고 실행한 후 서버에 완료를 알립니다.")
     @PostMapping("/ack")
     public ResponseEntity<DeviceControlCommandResponseDto> acknowledgeCommand(
-            @Valid @RequestBody CommandAckRequestDto request) {
-        return ResponseEntity.ok(deviceControlService.acknowledgeCommand(request));
+            @Valid @RequestBody CommandAckRequestDto ackRequest,
+            HttpServletRequest request) {
+        return ResponseEntity.ok(deviceControlService.acknowledgeCommand(
+                ackRequest,
+                (String) request.getAttribute(DeviceApiKeyAuthFilter.AUTHENTICATED_DEVICE_ID_ATTRIBUTE)));
     }
 
     @Operation(summary = "기기 현재 상태 조회",

--- a/src/main/java/com/smartfarm/server/control/service/DeviceControlService.java
+++ b/src/main/java/com/smartfarm/server/control/service/DeviceControlService.java
@@ -23,11 +23,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.springframework.data.domain.PageRequest;
 
 @Slf4j
 @Service
@@ -191,9 +188,12 @@ public class DeviceControlService {
      * PC 클라이언트가 명령 실행 후 확인(ACK)을 보냅니다.
      */
     @Transactional
-    public DeviceControlCommandResponseDto acknowledgeCommand(CommandAckRequestDto request) {
+    public DeviceControlCommandResponseDto acknowledgeCommand(CommandAckRequestDto request, String authenticatedDeviceId) {
         DeviceControlCommand command = commandRepository.findById(request.commandId())
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMAND_NOT_FOUND));
+        if (authenticatedDeviceId == null || !command.getDeviceId().equals(authenticatedDeviceId)) {
+            throw new CustomException(ErrorCode.DEVICE_ACCESS_DENIED);
+        }
         command.acknowledge();
         DeviceControlCommandResponseDto response = DeviceControlCommandResponseDto.from(command);
         // ACK 완료 상태를 대시보드에 실시간 푸시
@@ -226,33 +226,18 @@ public class DeviceControlService {
      */
     @Transactional(readOnly = true)
     public Map<String, Boolean> getDeviceState(String deviceId) {
-        List<String> allTypes = List.of(
-                "COOLING_FAN_ON", "COOLING_FAN_OFF",
-                "HEATER_ON", "HEATER_OFF",
-                "HUMIDIFIER_ON", "HUMIDIFIER_OFF"
-        );
-        // 기기 유형 3종 × ON/OFF 2종 = 최대 6건으로 상태 판단에 충분
-        List<DeviceControlCommand> commands = commandRepository
-                .findAllAcknowledgedByDeviceIdAndTypes(deviceId, CommandStatus.ACKNOWLEDGED, allTypes, PageRequest.of(0, 6));
-
-        boolean coolingFanOn = commands.stream()
-                .filter(c -> c.getCommandType().startsWith("COOLING_FAN"))
-                .map(c -> "COOLING_FAN_ON".equals(c.getCommandType()))
-                .findFirst()
-                .orElse(false);
-
-        boolean heaterOn = commands.stream()
-                .filter(c -> c.getCommandType().startsWith("HEATER"))
-                .map(c -> "HEATER_ON".equals(c.getCommandType()))
-                .findFirst()
-                .orElse(false);
-
-        boolean humidifierOn = commands.stream()
-                .filter(c -> c.getCommandType().startsWith("HUMIDIFIER"))
-                .map(c -> "HUMIDIFIER_ON".equals(c.getCommandType()))
-                .findFirst()
-                .orElse(false);
+        boolean coolingFanOn = isLatestCommandOn(deviceId, List.of("COOLING_FAN_ON", "COOLING_FAN_OFF"), "COOLING_FAN_ON");
+        boolean heaterOn = isLatestCommandOn(deviceId, List.of("HEATER_ON", "HEATER_OFF"), "HEATER_ON");
+        boolean humidifierOn = isLatestCommandOn(deviceId, List.of("HUMIDIFIER_ON", "HUMIDIFIER_OFF"), "HUMIDIFIER_ON");
 
         return Map.of("coolingFanOn", coolingFanOn, "heaterOn", heaterOn, "humidifierOn", humidifierOn);
+    }
+
+    private boolean isLatestCommandOn(String deviceId, List<String> commandTypes, String onCommandType) {
+        return commandRepository
+                .findTopByDeviceIdAndCommandTypeInAndStatusOrderByCreatedAtDesc(
+                        deviceId, commandTypes, CommandStatus.ACKNOWLEDGED)
+                .map(command -> onCommandType.equals(command.getCommandType()))
+                .orElse(false);
     }
 }

--- a/src/main/java/com/smartfarm/server/dashboard/controller/SseController.java
+++ b/src/main/java/com/smartfarm/server/dashboard/controller/SseController.java
@@ -1,11 +1,17 @@
 package com.smartfarm.server.dashboard.controller;
 
+import com.smartfarm.server.common.exception.CustomException;
+import com.smartfarm.server.common.exception.ErrorCode;
+import com.smartfarm.server.common.security.UserPrincipal;
 import com.smartfarm.server.dashboard.service.SseEmitterService;
+import com.smartfarm.server.device.filter.DeviceApiKeyAuthFilter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +30,11 @@ public class SseController {
             summary = "대시보드 실시간 센서 데이터 구독",
             description = "브라우저에서 특정 기기의 센서 데이터를 실시간으로 수신합니다. 인증 필요.")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@RequestParam String deviceId, HttpServletResponse response) {
+    public SseEmitter subscribe(
+            @RequestParam String deviceId,
+            HttpServletResponse response,
+            @AuthenticationPrincipal UserPrincipal principal) {
+        assertDeviceAccess(principal, deviceId);
         response.setHeader("X-Accel-Buffering", "no");
         response.setHeader("Cache-Control", "no-cache");
         return sseEmitterService.subscribe(deviceId);
@@ -37,9 +47,19 @@ public class SseController {
                         + "PC 클라이언트는 명령 수신 후 /api/device-control/ack 로 실행 확인을 전송해야 합니다. "
                         + "인증 불필요 (PC 클라이언트 전용).")
     @GetMapping(value = "/device-command-stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribeDeviceCommandStream(@RequestParam String deviceId, HttpServletResponse response) {
+    public SseEmitter subscribeDeviceCommandStream(
+            @RequestParam String deviceId,
+            HttpServletResponse response,
+            HttpServletRequest request) {
+        DeviceApiKeyAuthFilter.assertAuthenticatedDevice(request, deviceId);
         response.setHeader("X-Accel-Buffering", "no");
         response.setHeader("Cache-Control", "no-cache");
         return sseEmitterService.subscribeDevice(deviceId);
+    }
+
+    private void assertDeviceAccess(UserPrincipal principal, String deviceId) {
+        if (principal == null || !principal.canAccess(deviceId)) {
+            throw new CustomException(ErrorCode.DEVICE_ACCESS_DENIED);
+        }
     }
 }

--- a/src/main/java/com/smartfarm/server/device/filter/DeviceApiKeyAuthFilter.java
+++ b/src/main/java/com/smartfarm/server/device/filter/DeviceApiKeyAuthFilter.java
@@ -1,6 +1,7 @@
 package com.smartfarm.server.device.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartfarm.server.common.exception.CustomException;
 import com.smartfarm.server.device.dto.DeviceConfigView;
 import com.smartfarm.server.common.exception.ErrorCode;
 import com.smartfarm.server.audit.service.AuditLogService;
@@ -37,6 +38,8 @@ public class DeviceApiKeyAuthFilter extends OncePerRequestFilter {
 
     public static final String HEADER_DEVICE_ID = "X-Device-Id";
     public static final String HEADER_API_KEY   = "X-Api-Key";
+    public static final String AUTHENTICATED_DEVICE_ID_ATTRIBUTE =
+            DeviceApiKeyAuthFilter.class.getName() + ".AUTHENTICATED_DEVICE_ID";
 
     /** API 키 인증이 필요한 PC 클라이언트 전용 경로 */
     private static final List<String> PROTECTED_PREFIXES = List.of(
@@ -103,7 +106,15 @@ public class DeviceApiKeyAuthFilter extends OncePerRequestFilter {
         }
 
         log.debug(">>> [API Key Auth] 인증 성공 — deviceId={}, path={}", deviceId, path);
+        request.setAttribute(AUTHENTICATED_DEVICE_ID_ATTRIBUTE, deviceId);
         filterChain.doFilter(request, response);
+    }
+
+    public static void assertAuthenticatedDevice(HttpServletRequest request, String requestedDeviceId) {
+        Object authenticated = request.getAttribute(AUTHENTICATED_DEVICE_ID_ATTRIBUTE);
+        if (!(authenticated instanceof String authenticatedDeviceId) || !authenticatedDeviceId.equals(requestedDeviceId)) {
+            throw new CustomException(ErrorCode.DEVICE_ACCESS_DENIED);
+        }
     }
 
     private boolean isProtectedPath(String path) {

--- a/src/main/java/com/smartfarm/server/sensor/controller/SensorController.java
+++ b/src/main/java/com/smartfarm/server/sensor/controller/SensorController.java
@@ -2,9 +2,11 @@ package com.smartfarm.server.sensor.controller;
 
 import com.smartfarm.server.sensor.dto.SensorRequestDto;
 import com.smartfarm.server.sensor.dto.SensorResponseDto;
+import com.smartfarm.server.device.filter.DeviceApiKeyAuthFilter;
 import com.smartfarm.server.sensor.service.SensorService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +24,10 @@ public class SensorController {
     @Operation(summary = "센서 데이터 수신 및 명령 반환",
             description = "기기(PC)가 3초마다 보내는 온도/습도 데이터를 수신하고, 임계치 초과 시 쿨링팬/히터 가동 명령을 응답으로 반환합니다.")
     @PostMapping("/data")
-    public ResponseEntity<SensorResponseDto> receiveSensorData(@Valid @RequestBody SensorRequestDto requestDto) {
+    public ResponseEntity<SensorResponseDto> receiveSensorData(
+            @Valid @RequestBody SensorRequestDto requestDto,
+            HttpServletRequest request) {
+        DeviceApiKeyAuthFilter.assertAuthenticatedDevice(request, requestDto.getDeviceId());
         SensorResponseDto responseDto = sensorService.processSensorData(requestDto);
         return ResponseEntity.ok(responseDto);
     }

--- a/src/test/java/com/smartfarm/server/config/DeviceApiKeyAuthFilterTest.java
+++ b/src/test/java/com/smartfarm/server/config/DeviceApiKeyAuthFilterTest.java
@@ -1,25 +1,38 @@
 package com.smartfarm.server.config;
 
 import com.smartfarm.server.audit.entity.AuditLog;
+import com.smartfarm.server.control.entity.CommandStatus;
+import com.smartfarm.server.control.entity.DeviceControlCommand;
+import com.smartfarm.server.control.repository.DeviceControlCommandRepository;
 import com.smartfarm.server.device.entity.DeviceConfig;
 import com.smartfarm.server.audit.repository.AuditLogRepository;
 import com.smartfarm.server.device.repository.DeviceConfigRepository;
 import com.smartfarm.server.device.filter.DeviceApiKeyAuthFilter;
+import com.smartfarm.server.sensor.dto.SensorRequestDto;
+import com.smartfarm.server.sensor.dto.SensorResponseDto;
+import com.smartfarm.server.sensor.service.SensorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -43,9 +56,16 @@ class DeviceApiKeyAuthFilterTest {
     private AuditLogRepository auditLogRepository;
 
     @Autowired
+    private DeviceControlCommandRepository commandRepository;
+
+    @Autowired
     private CacheManager cacheManager;
 
+    @MockBean
+    private SensorService sensorService;
+
     private static final String TEST_DEVICE_ID = "TEST-PC-001";
+    private static final String OTHER_DEVICE_ID = "OTHER-PC-001";
     private String testApiKey;
     private static final String PROTECTED_ENDPOINT = "/api/sensor/data";
 
@@ -58,6 +78,7 @@ class DeviceApiKeyAuthFilterTest {
         }
 
         auditLogRepository.deleteAll();
+        commandRepository.deleteAll();
         deviceConfigRepository.deleteAll();
 
         // 테스트용 기기 설정 등록
@@ -67,11 +88,20 @@ class DeviceApiKeyAuthFilterTest {
                 .build();
 
         deviceConfigRepository.save(config);
+        deviceConfigRepository.save(DeviceConfig.builder()
+                .deviceId(OTHER_DEVICE_ID)
+                .build());
 
         // 저장된 설정에서 생성된 API 키를 조회하여 테스트에 사용
         DeviceConfig retrievedConfig = deviceConfigRepository.findByDeviceId(TEST_DEVICE_ID)
                 .orElseThrow(() -> new RuntimeException("Device config not found after save"));
         testApiKey = retrievedConfig.getApiKey();
+
+        when(sensorService.processSensorData(any(SensorRequestDto.class)))
+                .thenReturn(SensorResponseDto.builder()
+                        .status("SUCCESS")
+                        .message("Data processed successfully")
+                        .build());
     }
 
     @Test
@@ -202,6 +232,56 @@ class DeviceApiKeyAuthFilterTest {
         // Then: AUTH_FAILURE 감사 로그가 없어야 함
         List<AuditLog> logs = auditLogRepository.findByDeviceIdOrderByCreatedAtDesc(TEST_DEVICE_ID, PageRequest.of(0, 10)).getContent();
         assertThat(logs).isEmpty();
+    }
+
+    @Test
+    void rejectsSensorDataWhenHeaderDeviceDoesNotMatchBodyDevice() throws Exception {
+        mockMvc.perform(post(PROTECTED_ENDPOINT)
+                .header(DeviceApiKeyAuthFilter.HEADER_DEVICE_ID, TEST_DEVICE_ID)
+                .header(DeviceApiKeyAuthFilter.HEADER_API_KEY, testApiKey)
+                .contentType("application/json")
+                .content("{\"deviceId\":\"" + OTHER_DEVICE_ID + "\",\"cpu_temperature\":25.5,\"humidity\":45.3,\"timestamp\":" + System.currentTimeMillis() + "}"))
+                .andExpect(status().isForbidden());
+
+        verify(sensorService, never()).processSensorData(any(SensorRequestDto.class));
+    }
+
+    @Test
+    void rejectsPendingCommandLookupForDifferentDevice() throws Exception {
+        mockMvc.perform(get("/api/device-control/pending")
+                .param("deviceId", OTHER_DEVICE_ID)
+                .header(DeviceApiKeyAuthFilter.HEADER_DEVICE_ID, TEST_DEVICE_ID)
+                .header(DeviceApiKeyAuthFilter.HEADER_API_KEY, testApiKey))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void rejectsDeviceCommandStreamForDifferentDevice() throws Exception {
+        mockMvc.perform(get("/api/sse/device-command-stream")
+                .param("deviceId", OTHER_DEVICE_ID)
+                .header(DeviceApiKeyAuthFilter.HEADER_DEVICE_ID, TEST_DEVICE_ID)
+                .header(DeviceApiKeyAuthFilter.HEADER_API_KEY, testApiKey))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void rejectsAckForCommandOwnedByDifferentDevice() throws Exception {
+        DeviceControlCommand command = commandRepository.save(DeviceControlCommand.builder()
+                .deviceId(OTHER_DEVICE_ID)
+                .commandType("COOLING_FAN_ON")
+                .status(CommandStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        mockMvc.perform(post("/api/device-control/ack")
+                .header(DeviceApiKeyAuthFilter.HEADER_DEVICE_ID, TEST_DEVICE_ID)
+                .header(DeviceApiKeyAuthFilter.HEADER_API_KEY, testApiKey)
+                .contentType("application/json")
+                .content("{\"commandId\":" + command.getId() + "}"))
+                .andExpect(status().isForbidden());
+
+        DeviceControlCommand reloaded = commandRepository.findById(command.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(CommandStatus.PENDING);
     }
 
     @Test

--- a/src/test/java/com/smartfarm/server/config/TestCacheConfig.java
+++ b/src/test/java/com/smartfarm/server/config/TestCacheConfig.java
@@ -1,0 +1,19 @@
+package com.smartfarm.server.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("test")
+public class TestCacheConfig {
+
+    @Bean
+    @Primary
+    public CacheManager testCacheManager() {
+        return new ConcurrentMapCacheManager("deviceConfigView");
+    }
+}

--- a/src/test/java/com/smartfarm/server/control/service/DeviceControlServiceTest.java
+++ b/src/test/java/com/smartfarm/server/control/service/DeviceControlServiceTest.java
@@ -1,0 +1,64 @@
+package com.smartfarm.server.control.service;
+
+import com.smartfarm.server.control.entity.CommandStatus;
+import com.smartfarm.server.control.entity.DeviceControlCommand;
+import com.smartfarm.server.control.repository.DeviceControlCommandRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class DeviceControlServiceTest {
+
+    private static final String DEVICE_ID = "TEST-PC-001";
+
+    @Autowired
+    private DeviceControlService deviceControlService;
+
+    @Autowired
+    private DeviceControlCommandRepository commandRepository;
+
+    @BeforeEach
+    void setUp() {
+        commandRepository.deleteAll();
+    }
+
+    @Test
+    void getDeviceStateUsesLatestAcknowledgedCommandPerActuatorType() {
+        LocalDateTime baseTime = LocalDateTime.now().minusMinutes(30);
+        saveCommand("HEATER_ON", baseTime);
+        saveCommand("HUMIDIFIER_ON", baseTime.plusMinutes(1));
+
+        saveCommand("COOLING_FAN_ON", baseTime.plusMinutes(2));
+        saveCommand("COOLING_FAN_OFF", baseTime.plusMinutes(3));
+        saveCommand("COOLING_FAN_ON", baseTime.plusMinutes(4));
+        saveCommand("COOLING_FAN_OFF", baseTime.plusMinutes(5));
+        saveCommand("COOLING_FAN_ON", baseTime.plusMinutes(6));
+        saveCommand("COOLING_FAN_OFF", baseTime.plusMinutes(7));
+
+        Map<String, Boolean> state = deviceControlService.getDeviceState(DEVICE_ID);
+
+        assertThat(state.get("coolingFanOn")).isFalse();
+        assertThat(state.get("heaterOn")).isTrue();
+        assertThat(state.get("humidifierOn")).isTrue();
+    }
+
+    private void saveCommand(String commandType, LocalDateTime createdAt) {
+        commandRepository.save(DeviceControlCommand.builder()
+                .deviceId(DEVICE_ID)
+                .commandType(commandType)
+                .status(CommandStatus.ACKNOWLEDGED)
+                .createdAt(createdAt)
+                .build());
+    }
+}

--- a/src/test/java/com/smartfarm/server/dashboard/controller/SseControllerAuthorizationTest.java
+++ b/src/test/java/com/smartfarm/server/dashboard/controller/SseControllerAuthorizationTest.java
@@ -1,0 +1,40 @@
+package com.smartfarm.server.dashboard.controller;
+
+import com.smartfarm.server.common.security.UserPrincipal;
+import com.smartfarm.server.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SseControllerAuthorizationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void rejectsDashboardSubscriptionForDifferentDevice() throws Exception {
+        mockMvc.perform(get("/api/sse/subscribe")
+                .param("deviceId", "OTHER-PC-001")
+                .with(user(principal("ROLE_USER", "TEST-PC-001"))))
+                .andExpect(status().isForbidden());
+    }
+
+    private UserPrincipal principal(String role, String linkedDeviceId) {
+        return new UserPrincipal(User.builder()
+                .username("viewer")
+                .password("password")
+                .role(role)
+                .linkedDeviceId(linkedDeviceId)
+                .build());
+    }
+}


### PR DESCRIPTION
## Summary
- Bind API-key authenticated device IDs to sensor, pending command, command stream, and ACK requests
- Add dashboard SSE per-device authorization
- Fix device state reconstruction to query the latest ACK per actuator type
- Add regression tests for API key/device mismatch, SSE authorization, and device state restoration
- Update README with current API/test notes and Redis-free test profile details

## Tests
- ./gradlew test